### PR TITLE
Add agnix – linter for AI agent configs (validates AGENTS.md, Codex configs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ OpenAI Codex CLI is Lightweight coding agent that runs in your terminal
 - [zcf](https://github.com/UfoMiao/zcf) - Zero-config, one-click setup for Claude Code & Codex with bilingual support, intelligent agent system and personalized AI assistant
 - [vsync](https://github.com/nicepkg/vsync) - Sync Skills, MCP servers, Agents & Commands across Claude Code, Cursor, OpenCode, and Codex with automatic format conversion (JSON ↔ TOML ↔ JSONC).
 - [just-every/code](https://github.com/just-every/code) - fork of openai/codex focused on real developer ergonomics: Browser integration, multi-agents, theming, and reasoning control — all while staying compatible with upstream.
+- [agnix](https://github.com/avifenesh/agnix) - Linter for AI agent configurations. Validates AGENTS.md, .codex/config.toml, skills, hooks, and MCP configs with 156 rules, auto-fix, and editor integration.
 
 ### Stat
 - [ccusage](https://github.com/ryoppippi/ccusage) - A CLI tool for analyzing Claude Code/Codex CLI usage from local JSONL files.


### PR DESCRIPTION
## Add agnix to Development Tools

[agnix](https://github.com/avifenesh/agnix) is a linter for AI agent configurations. It validates `AGENTS.md`, `.codex/config.toml`, skills, hooks, MCP configs, and more — with 156 rules, auto-fix support, and editor integration (VS Code, Neovim, Zed, JetBrains).

Particularly relevant to Codex CLI users since agnix validates:
- **AGENTS.md** files (the format used by Codex CLI and 20k+ open-source projects)
- **.codex/config.toml** configuration files
- MCP server configurations
- Skill definitions and hooks

It ships as a CLI, LSP server, and MCP server, written in Rust.