### PR TITLE
Add BurnRate - AI coding cost analytics tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ OpenAI Codex CLI is Lightweight coding agent that runs in your terminal
 
 ### Stat
 - [ccusage](https://github.com/ryoppippi/ccusage) - A CLI tool for analyzing Claude Code/Codex CLI usage from local JSONL files.
+- [BurnRate](https://github.com/burnrate-dev/burnrate) - AI coding cost analytics CLI that tracks usage and costs across 7 providers (Claude Code, Cursor, Copilot, Windsurf, Aider, Cline, Codex) with a real-time dashboard, 46 optimization rules, and rate limit monitoring.
 
 #### Editor
 - [zed](https://github.com/zed-industries/zed) - Code at the speed of thought – Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.


### PR DESCRIPTION
[BurnRate](https://getburnrate.io) is a local-first CLI tool that tracks AI coding tool usage and costs across 7 providers: Claude Code, Cursor, GitHub Copilot, Windsurf, Aider, Cline, and OpenAI Codex.

- Real-time cost analytics dashboard
- 46 optimization rules to reduce spending
- Rate limit monitoring and team budgets
- Written in Go, single binary

GitHub: https://github.com/burnrate-dev/burnrate