### PR TITLE
Add Untether — Telegram bridge with Codex CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ OpenAI Codex CLI is Lightweight coding agent that runs in your terminal
 - [CodexFlow](https://github.com/lulu-sk/CodexFlow) - CodexFlow is an enhanced GUI tool designed for Codex CLI, focused on improving conversation management and interaction.
 - [Codex-webui](https://github.com/harryneopotter/Codex-webui) - A minimal webui to run Codex-CLI locally with a UI, session resume and persistent memory (Un-official)
 - [AionUi](https://github.com/iOfficeAI/AionUi) - Free, local, open-source GUI app for Gemini CLI — Better Chat UI, File Management, AI image editing, multi-agent support, multi-LLMs
+- [Untether](https://github.com/littlebearapps/untether) - Telegram bridge for Codex CLI (and 5 other agents). Send tasks by voice, stream progress, toggle approval policy (full auto/safe) via inline buttons
 
 ### Development Tools
 - [humanlayer](https://github.com/humanlayer/humanlayer) - The best way to get AI coding agents to solve hard problems in complex codebases.


### PR DESCRIPTION
Adds [Untether](https://github.com/littlebearapps/untether) to the WebUI & App section.

Untether connects Codex CLI to a Telegram bot for remote task management.

Codex-specific features:
- Approval policy via `/config` — full auto (default) or safe (untrusted tools blocked)
- Model override and reasoning levels via `/config`
- Device re-auth via `/auth`
- Voice note transcription
- Progress streaming with tool call details
- Session resume

Also supports Claude Code, OpenCode, Pi, Gemini CLI, and Amp.

MIT licensed, `uv tool install untether`.