### PR TITLE
Add ru-text: Russian text quality plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ OpenAI Codex CLI is Lightweight coding agent that runs in your terminal
 - [agnix](https://github.com/avifenesh/agnix) - Linter for AI agent configurations. Validates AGENTS.md, .codex/config.toml, skills, hooks, and MCP configs with 156 rules, auto-fix, and editor integration.
 - [caliber](https://github.com/rely-ai-org/caliber) - CLI that fingerprints your codebase and generates AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md, skills, MCPs) for Claude Code, Cursor, and Codex. Scores your setup 0–100.
 - [bernstein](https://github.com/chernistry/bernstein) - Parallel multi-agent orchestrator — spawns Codex CLI, Claude Code, and Gemini CLI simultaneously on isolated git worktrees, verifies with tests, auto-commits working code. Zero LLM tokens on coordination.
+- [ru-text](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence.
 
 ### Stat
 - [ccusage](https://github.com/ryoppippi/ccusage) - A CLI tool for analyzing Claude Code/Codex CLI usage from local JSONL files.


### PR DESCRIPTION
## Summary

- Adds [ru-text](https://github.com/talkstream/ru-text) to the Development Tools section
- ~1,040 rules covering typography, info-style, editorial, UX writing, and business correspondence for Russian text quality