### PR TITLE
Add TokRepo registry entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ OpenAI Codex CLI is Lightweight coding agent that runs in your terminal
 - [caliber](https://github.com/rely-ai-org/caliber) - CLI that fingerprints your codebase and generates AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md, skills, MCPs) for Claude Code, Cursor, and Codex. Scores your setup 0–100.
 - [bernstein](https://github.com/chernistry/bernstein) - Parallel multi-agent orchestrator — spawns Codex CLI, Claude Code, and Gemini CLI simultaneously on isolated git worktrees, verifies with tests, auto-commits working code. Zero LLM tokens on coordination.
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence.
+- [TokRepo](https://github.com/henu-wang/tokrepo) - Canonical GitHub landing page for the TokRepo open registry, with links to a Codex-compatible skill repo, MCP server, and installable AI assets such as prompts, workflows, and MCP configs.
 
 ### Stat
 - [ccusage](https://github.com/ryoppippi/ccusage) - A CLI tool for analyzing Claude Code/Codex CLI usage from local JSONL files.


### PR DESCRIPTION
Adds TokRepo under `Development Tools`.

Why it fits:
- it is a GitHub-native registry entry point for installable AI assets
- it links Codex users to a Codex-compatible skill repo, MCP server, and other reusable assets
- it complements the existing multi-agent and configuration tools already listed in this section
