### PR TITLE
Add WhereMyTokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ OpenAI Codex CLI is Lightweight coding agent that runs in your terminal
 
 ### Stat
 - [ccusage](https://github.com/ryoppippi/ccusage) - A CLI tool for analyzing Claude Code/Codex CLI usage from local JSONL files.
+- [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) - Windows tray app for monitoring Claude Code and Codex token usage, costs, sessions, and rate limits from local JSONL logs.
 
 #### Editor
 - [zed](https://github.com/zed-industries/zed) - Code at the speed of thought – Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.


### PR DESCRIPTION
## Summary
- Add WhereMyTokens under the Stat section.
- The app monitors Claude Code and Codex token usage, costs, sessions, and rate limits from local JSONL logs in a Windows tray UI.

## Notes
- Public GitHub repo, MIT licensed, actively maintained.
- Single README entry following the existing format.