### PR TITLE
Add Bring Your AI to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ OpenAI Codex CLI is Lightweight coding agent that runs in your terminal
 - [dotai](https://github.com/udecode/dotai) - Context Manager for Claude Code Plugins + Codex + Cursor.
 - [zcf](https://github.com/UfoMiao/zcf) - Zero-config, one-click setup for Claude Code & Codex with bilingual support, intelligent agent system and personalized AI assistant
 - [vsync](https://github.com/nicepkg/vsync) - Sync Skills, MCP servers, Agents & Commands across Claude Code, Cursor, OpenCode, and Codex with automatic format conversion (JSON ↔ TOML ↔ JSONC).
+- [Bring Your AI](https://bringyour.ai/claude-code-to-codex) - Local-first Claude Code to Codex migration tool that keeps harness files local, maps AGENTS.md / CLAUDE.md guidance, MCP config, and skills, and records non-equivalent hooks as validation notes.
 - [just-every/code](https://github.com/just-every/code) - fork of openai/codex focused on real developer ergonomics: Browser integration, multi-agents, theming, and reasoning control — all while staying compatible with upstream.
 - [agnix](https://github.com/avifenesh/agnix) - Linter for AI agent configurations. Validates AGENTS.md, .codex/config.toml, skills, hooks, and MCP configs with 156 rules, auto-fix, and editor integration.
 - [caliber](https://github.com/rely-ai-org/caliber) - CLI that fingerprints your codebase and generates AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md, skills, MCPs) for Claude Code, Cursor, and Codex. Scores your setup 0–100.


### PR DESCRIPTION
Adds Bring Your AI to Development Tools as a local-first Claude Code -> Codex migration path.

The fit here is harness portability, not prompt syncing. It keeps AGENTS.md / CLAUDE.md guidance, skills, and MCP config local, and it documents hook differences, secret-reference checks, and other non-equivalent behavior in the Codex import checklist and validation notes.