### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ OpenAI Codex CLI is Lightweight coding agent that runs in your terminal
 
 ### Stat
 - [ccusage](https://github.com/ryoppippi/ccusage) - A CLI tool for analyzing Claude Code/Codex CLI usage from local JSONL files.
+- [agenttrace](https://github.com/luoyuctl/agenttrace) - Local TUI for inspecting AI coding-agent session logs, usage, cost, latency, tool failures, diffs, and CI gates.
 - [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) - Windows tray app for monitoring Claude Code and Codex token usage, costs, sessions, and rate limits from local JSONL logs.
 
 #### Editor


### PR DESCRIPTION
Adds agenttrace to the Stat section as a local TUI for inspecting AI coding-agent session logs and usage.\n\nValidation:\n- git diff --check