### PR TITLE
Add ToutKit to WebUI & App

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ OpenAI Codex CLI is Lightweight coding agent that runs in your terminal
 - [Untether](https://github.com/littlebearapps/untether) - Telegram bridge for Codex CLI (and 5 other agents). Send tasks by voice, stream progress, toggle approval policy (full auto/safe) via inline buttons
 - [IM.codes](https://github.com/im4codes/imcodes) - The IM for agents: a mobile/web control layer for Codex CLI and other terminal-based coding agents, with terminal access, file browsing, git views, localhost preview, notifications, and multi-agent workflows.
 - [Onepilot](https://onepilotapp.com) - Native iOS SSH terminal for Codex CLI and Claude Code. Full PTY, GitHub integration, localhost forwarding, live file editing, and one-click AI agent deployment via OpenClaw. [App Store](https://apps.apple.com/app/onepilot-ai-terminal/id6743826919).
+- [ToutKit](https://github.com/toutkit/toutkit) - Desktop notebook with a built-in terminal that runs Codex CLI alongside Claude Code and Gemini; an in-app webview renders whatever the agent writes inline, and each note is a self-contained folder with its own SQLite, files, and scripts. Local-first, Electron, AGPL-3.0.
 
 ### Development Tools
 - [humanlayer](https://github.com/humanlayer/humanlayer) - The best way to get AI coding agents to solve hard problems in complex codebases.


### PR DESCRIPTION
Adds [**ToutKit**](https://github.com/toutkit/toutkit) to **WebUI & App**.

ToutKit is a local-first desktop notebook that pairs a sidebar of notes with a built-in terminal for Codex CLI (alongside Claude Code and Gemini CLI) and an in-app webview that renders whatever the agent writes inline — so answers come back as interactive HTML pages instead of walls of text. Each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool without leaving your filesystem.

Section fit: closest precedents are happy, CodexFlow, AionUi, and Untether — desktop/GUI shells that wrap Codex CLI in a richer interface.

- Repo: https://github.com/toutkit/toutkit
- License: AGPL-3.0
- Stack: Electron / JavaScript
- Cross-platform: macOS, Windows, Linux