### PR TITLE
Add ejentum-mcp under Tools > GUI & MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ OpenAI Codex CLI is Lightweight coding agent that runs in your terminal
 - [MCP Linker](https://github.com/milisp/mcp-linker) - GUI for managing MCP configs for Codex CLI
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - MCP server that generates app icons, favicons, OG images, logos, and wordmarks by routing requests across 30+ image generation models. Zero API key needed on first run via free-tier providers.
 - [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data extraction skill & MCP server for AI coding agents. 20 tools: followers, tweets, replies, mentions, lists, hashtags, spaces & more.
+- [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) - Reasoning Harness MCP server. Library of 679 cognitive operations engineered in natural language across four harnesses (reasoning, code, anti-deception, memory). Each call retrieves a task-matched scaffold (failure pattern, procedure, suppression vectors, falsification test) the agent ingests before responding. Free tier 100 calls.
 ### setup tool
 - [codex-1up](https://github.com/regenrek/codex-1up) - equips your Codex CLI coding agent with powerful tools.
 - [codex-universal](https://github.com/openai/codex-universal) - Base docker image used in Codex environments


### PR DESCRIPTION
Adds [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) under **Tools > GUI & MCP**, after `x-twitter-scraper`.

## What it is

A stdio MCP server (npm `ejentum-mcp`, MIT, free tier 100 calls) exposing a library of 679 cognitive operations engineered in natural language across four harnesses (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`). Each call retrieves a task-matched scaffold (failure pattern, executable procedure, suppression vectors, falsification test) the agent ingests before responding.

## Install in Codex

Add to `~/.codex/config.toml`:

```toml
[mcp_servers.ejentum]
command = "npx"
args = ["-y", "ejentum-mcp"]
env = { EJENTUM_API_KEY = "<your-key>" }
```

Free tier (100 calls, no card) at https://ejentum.com/pricing.

## About

- Repo: https://github.com/ejentum/ejentum-mcp (MIT)
- Walkthrough: https://ejentum.com/docs/claude_code_guide
- Backed by the "Under Pressure" Zenodo preprint (DOI 10.5281/zenodo.19392715)
- Signed commit on the PR branch.

Maintainer is me; happy to address review feedback.