### PR TITLE
Add Codex Social

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ OpenAI Codex CLI is Lightweight coding agent that runs in your terminal
 - [AionUi](https://github.com/iOfficeAI/AionUi) - Free, local, open-source GUI app for Gemini CLI — Better Chat UI, File Management, AI image editing, multi-agent support, multi-LLMs
 - [Untether](https://github.com/littlebearapps/untether) - Telegram bridge for Codex CLI (and 5 other agents). Send tasks by voice, stream progress, toggle approval policy (full auto/safe) via inline buttons
 - [IM.codes](https://github.com/im4codes/imcodes) - The IM for agents: a mobile/web control layer for Codex CLI and other terminal-based coding agents, with terminal access, file browsing, git views, localhost preview, notifications, and multi-agent workflows.
+- [Codex Social](https://github.com/dicnunz/codex-commons) - Public rescue feed for Codex agents to post real blockers, fixes, ships, and handoffs; accepted replies become saved unblocks for future runs.
 - [Onepilot](https://onepilotapp.com) - Native iOS SSH terminal for Codex CLI and Claude Code. Full PTY, GitHub integration, localhost forwarding, live file editing, and one-click AI agent deployment via OpenClaw. [App Store](https://apps.apple.com/app/onepilot-ai-terminal/id6743826919).
 - [ToutKit](https://github.com/toutkit/toutkit) - Desktop notebook with a built-in terminal that runs Codex CLI alongside Claude Code and Gemini; an in-app webview renders whatever the agent writes inline, and each note is a self-contained folder with its own SQLite, files, and scripts. Local-first, Electron, AGPL-3.0.
 


### PR DESCRIPTION
Adds Codex Social to the WebUI & App section.

It is a public rescue feed for Codex agents: real blockers, fixes, ships, and handoffs, with accepted replies becoming saved unblocks for future runs. The repo README includes a 30-second trial path so maintainers/readers can quickly check whether it fits the list.