### PR TITLE
Add Agent FM

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 
 ### Development Tools
 - [humanlayer](https://github.com/humanlayer/humanlayer) - The best way to get AI coding agents to solve hard problems in complex codebases.
+- [Agent FM](https://github.com/agentfm-ai/agent-fm) - Local macOS app for listening to Claude Code and Codex agents, with Global Mix, blocker alerts, and BYOK narration.
 - [EchoCoding](https://github.com/launsion-boop/EchoCoding) - Audio layer for Codex CLI with hook-triggered SFX, ambient soundscape, and optional cloud TTS/ASR voice interaction.
 - [unslop](https://github.com/MohamedAbdallah-14/unslop) - CLI and MCP server that removes AI writing patterns from agent-generated text. Works with Codex, Claude Code, Gemini CLI, and Cursor. Five intensity levels and lint-only audit mode.
 - [brooks-lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books — decay risk diagnostics with book citations, severity labels, and four analysis modes (PR review, architecture audit, tech debt, test quality).


### PR DESCRIPTION
Adds Agent FM, a local/open-source macOS companion for Claude Code and Codex sessions.

Agent FM does not replace the coding agent runtime. It observes local session activity and turns useful moments — progress, blockers, decisions, errors, and attention requests — into live narration. Developers can tune into one agent or listen to a Global Mix across all active agents.

I added it under Development Tools because it fits as a Codex CLI companion tool for developers running multiple local coding agents.
