### PR TITLE
Add click-to-mcp to MCP server section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 
 ### MCP server
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - MCP server that generates app icons, favicons, OG images, logos, and wordmarks by routing requests across 30+ image generation models. Zero API key needed on first run via free-tier providers.
-- [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) - Reasoning Harness MCP server. Library of 679 cognitive operations engineered in natural language across four harnesses (reasoning, code, anti-deception, memory). Each call retrieves a task-matched scaffold (failure pattern, procedure, suppression vectors, falsification test) the agent ingests before responding. Free tier 100 calls.
+- [ejentum-mcp](https://github.com/ejentum/ejentum-mcp)
+- [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) - Auto-wrap any Python Click/Typer CLI as an MCP server. Zero-code transformation that introspects CLI commands and exposes them as MCP tools. Works with Codex CLI, Claude Code, and any MCP client. `pip install click-to-mcp` - Reasoning Harness MCP server. Library of 679 cognitive operations engineered in natural language across four harnesses (reasoning, code, anti-deception, memory). Each call retrieves a task-matched scaffold (failure pattern, procedure, suppression vectors, falsification test) the agent ingests before responding. Free tier 100 calls.
 
 ### setup tool
 - [codex-1up](https://github.com/regenrek/codex-1up) - equips your Codex CLI coding agent with powerful tools.


### PR DESCRIPTION
Adds [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) to the MCP server section.

click-to-mcp auto-wraps any Python Click/Typer CLI as an MCP server with zero code changes. Works with Codex CLI and any other MCP client — run `click-to-mcp serve <your-cli>` and add the config to your Codex MCP settings.

- Auto-discovers Click commands, typer apps, and CLI entry points
- Supports stdio and HTTP+SSE transports  
- `pip install click-to-mcp`

Enables the large ecosystem of Python CLI tools to become MCP servers instantly — no boilerplate required.