### PR TITLE
Add Codex on Telegram to WebUI & App

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 - [IM.codes](https://github.com/im4codes/imcodes) - The IM for agents: a mobile/web control layer for Codex CLI and other terminal-based coding agents, with terminal access, file browsing, git views, localhost preview, notifications, and multi-agent workflows.
 - [Onepilot](https://onepilotapp.com) - Native iOS SSH terminal for Codex CLI and Claude Code. Full PTY, GitHub integration, localhost forwarding, live file editing, and one-click AI agent deployment via OpenClaw. [App Store](https://apps.apple.com/app/onepilot-ai-terminal/id6743826919).
 - [ToutKit](https://github.com/toutkit/toutkit) - Desktop notebook with a built-in terminal that runs Codex CLI alongside Claude Code and Gemini; an in-app webview renders whatever the agent writes inline, and each note is a self-contained folder with its own SQLite, files, and scripts. Local-first, Electron, AGPL-3.0.
+- [Codex on Telegram](https://github.com/leoshenzh/codex-on-telegram) - Self-hosted macOS bridge that drives your local Codex CLI (or Claude Code) sessions from Telegram. Attach to a session already running on your machine, approve permission prompts in chat, run per-topic parallel sessions, and resume the same session after a restart.
 
 ### Development Tools
 - [humanlayer](https://github.com/humanlayer/humanlayer) - The best way to get AI coding agents to solve hard problems in complex codebases.


### PR DESCRIPTION
Adds **Codex on Telegram** to the **Tools > WebUI & App** section.

- **Project link:** https://github.com/leoshenzh/codex-on-telegram
- **What it is:** A self-hosted macOS bridge that drives your local Codex CLI (or Claude Code) coding sessions from Telegram — attach to a session already running on your machine, approve permission prompts in chat, run per-topic parallel sessions, and resume the same session after a restart.
- **License:** MIT (open source). Node >= 20, macOS.

It fits alongside the other remote-control bridges in this section, e.g. `Untether` (Telegram bridge for Codex CLI) and `IM.codes`. Single-line addition, appended to the end of the section to match the existing order.