### PR TITLE
Add agentbox to Session manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 - [codmate](https://github.com/loocor/codmate) - a macOS SwiftUI app for managing CLI AI sessions
 - [agent-sessions](https://github.com/jazzyalex/agent-sessions) - Session browser + usage tracker for Codex CLI and Claude Code. Search ALL past sessions, filter by folder·repo, resume instantly
 - [codexsm](https://github.com/milisp/codexsm) - Codex session manager, Cross platform GUI. rename, view, delete session file. one click resume session
+- [agentbox](https://github.com/madarco/agentbox) - Run multiple Codex (and Claude Code / OpenCode) sessions in parallel, each in its own sandboxed box — local Docker or cloud VMs (Hetzner/Daytona/Vercel/E2B). Sub-1s checkpoint starts, per-box browser + VS Code, and a dashboard to switch between boxes.
 
 ### WebUI & App
 - [happy](https://github.com/slopus/happy) - Mobile and Web client for Codex and Claude Code, with realtime voice, encryption and fully featured


### PR DESCRIPTION
Adds [**agentbox**](https://github.com/madarco/agentbox) (MIT) to **Tools → Session manager**.

AgentBox runs multiple Codex (and Claude Code / OpenCode) sessions in parallel, each teleported into its own sandboxed box — local Docker or cloud VMs (Hetzner/Daytona/Vercel/E2B) — with sub-1s starts from checkpoints, a per-box browser + VS Code, and a dashboard to switch between boxes. It has a dedicated `agentbox codex` command.

Project link: https://github.com/madarco/agentbox ⭐ this list too.