### PR TITLE
feat: add TWZRD Agent Intel MCP to GUI & MCP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 - [MCP Linker](https://github.com/milisp/mcp-linker) - GUI for managing MCP configs for Codex CLI
 - [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data extraction skill & MCP server for AI coding agents. 20 tools: followers, tweets, replies, mentions, lists, hashtags, spaces & more.
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring MCP for AI agents on Solana. score_agent, preflight_check (free), get_trust_receipt (x402 USDC). Verify wallet identity before autonomous on-chain transactions. `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
+
 ### MCP server
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - MCP server that generates app icons, favicons, OG images, logos, and wordmarks by routing requests across 30+ image generation models. Zero API key needed on first run via free-tier providers.
 - [ejentum-mcp](https://github.com/ejentum/ejentum-mcp)


### PR DESCRIPTION
Adds TWZRD Agent Intel (https://intel.twzrd.xyz) to the GUI & MCP section. Trust scoring MCP for AI agents on Solana — verify wallet identity before autonomous on-chain transactions. Free: score_agent/preflight_check. Paid x402 USDC: get_trust_receipt. Zero-install remote MCP.