### PR TITLE
Add Relay Baton

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 ### Development Tools
 - [humanlayer](https://github.com/humanlayer/humanlayer) - The best way to get AI coding agents to solve hard problems in complex codebases.
 - [Agent FM](https://github.com/agentfm-ai/agent-fm) - Local macOS app for listening to Claude Code and Codex agents, with Global Mix, blocker alerts, and BYOK narration.
+- [Relay Baton](https://github.com/guorunjie/codex-relay-baton-guardian) - Local Codex Desktop/CLI recovery monitor for long-running tasks. Detects compact failures and context-window overflow, then queues audited handoff bundles.
 - [EchoCoding](https://github.com/launsion-boop/EchoCoding) - Audio layer for Codex CLI with hook-triggered SFX, ambient soundscape, and optional cloud TTS/ASR voice interaction.
 - [unslop](https://github.com/MohamedAbdallah-14/unslop) - CLI and MCP server that removes AI writing patterns from agent-generated text. Works with Codex, Claude Code, Gemini CLI, and Cursor. Five intensity levels and lint-only audit mode.
 - [brooks-lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books — decay risk diagnostics with book citations, severity labels, and four analysis modes (PR review, architecture audit, tech debt, test quality).


### PR DESCRIPTION
Adds Relay Baton under Development Tools.

Relay Baton is a local Codex Desktop/CLI recovery monitor for long-running tasks. It detects compact failures and context-window overflow, preserves the latest task state, and queues audited handoff bundles.

Project: https://github.com/guorunjie/codex-relay-baton-guardian
npm: https://www.npmjs.com/package/codex-relay-baton-guardian