### PR TITLE
Add Hephaestus

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 
 ### Development Tools
 - [humanlayer](https://github.com/humanlayer/humanlayer) - The best way to get AI coding agents to solve hard problems in complex codebases.
+- [Hephaestus](https://github.com/agentlas-ai/Hephaestus) - Open Agent OS for Claude Code, Codex, and Cursor: meta-agent builder, A2A Hub routing, local ontology, and memory/security gates.
 - [Agent FM](https://github.com/agentfm-ai/agent-fm) - Local macOS app for listening to Claude Code and Codex agents, with Global Mix, blocker alerts, and BYOK narration.
 - [Relay Baton](https://github.com/guorunjie/codex-relay-baton-guardian) - Local Codex Desktop/CLI recovery monitor for long-running tasks. Detects compact failures and context-window overflow, then queues audited handoff bundles.
 - [EchoCoding](https://github.com/launsion-boop/EchoCoding) - Audio layer for Codex CLI with hook-triggered SFX, ambient soundscape, and optional cloud TTS/ASR voice interaction.


### PR DESCRIPTION
## Summary
- Add Hephaestus to Development Tools.
- Hephaestus is an open Agent OS for Claude Code, Codex, and Cursor with meta-agent building, A2A Hub routing, local ontology, and memory/security gates.

## Source
- https://github.com/agentlas-ai/Hephaestus