### PR TITLE
Add Codex AGENTS.md Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 - [SwarmClaw](https://github.com/swarmclawai/swarmclaw) - Self-hosted multi-agent runtime that delegates to Codex CLI alongside Claude Code, Gemini CLI, OpenCode, Copilot CLI, Cursor Agent, Goose, Qwen Code, and Droid. Org chart view, schedules, runtime skills, persistent memory, and reviewed conversation-to-skill learning. MCP-native (server and client). Electron desktop app, CLI, and Docker.
 - [Alfred](https://github.com/luminik-io/alfred-os) - Self-hosted runtime that turns scoped GitHub issues into reviewed pull requests through autonomous Codex CLI and Claude Code agents. Per-firing git worktrees, label-driven state machine (agent:implement → agent:in-flight → agent:pr-open → agent:done), role-based engine routing across Codex and Claude, and Slack reporting. Python, MIT, macOS/Linux.
 - [Codex First Task Prompt Generator](https://ronnie2025.github.io/ai-agent-workbench-starter-pack/codex-first-task-prompt-generator.html) - Free web tool that turns a Codex CLI project goal into a scoped first-task prompt with constraints and acceptance checks.
+- [AGENTS.md Generator for Codex CLI](https://github.com/Ronnie2025/codex-agents-md-generator) - Free browser tool that generates project-level AGENTS.md files with commands, file boundaries, safety rules, and acceptance checks.
 
 ### Stat
 - [ccusage](https://github.com/ryoppippi/ccusage) - A CLI tool for analyzing Claude Code/Codex CLI usage from local JSONL files.


### PR DESCRIPTION
Adds a free AGENTS.md generator for Codex CLI users.

Resource: https://github.com/Ronnie2025/codex-agents-md-generator

Why it fits: it helps Codex CLI users generate project-level AGENTS.md files with commands, file boundaries, safety rules, and acceptance checks.

The resource is free, has no affiliate links, and is maintained by Ronnie2025.