### PR TITLE
Add ralph-harness development tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 
 ### Development Tools
 - [humanlayer](https://github.com/humanlayer/humanlayer) - The best way to get AI coding agents to solve hard problems in complex codebases.
+- [ralph-harness](https://github.com/rxdt/py_ralph_frame) - Minimal repo-local loop scaffold for Codex CLI, Claude Code, and Gemini CLI. Uses `PROMPT.md`, specs, fresh-context iterations, git hooks, CI verification, and hard iteration/time caps so agents make small gated commits instead of drifting in one long chat.
 - [Hephaestus](https://github.com/agentlas-ai/Hephaestus) - Open Agent OS for Claude Code, Codex, and Cursor: meta-agent builder, A2A Hub routing, local ontology, and memory/security gates.
 - [Agent FM](https://github.com/agentfm-ai/agent-fm) - Local macOS app for listening to Claude Code and Codex agents, with Global Mix, blocker alerts, and BYOK narration.
 - [Relay Baton](https://github.com/guorunjie/codex-relay-baton-guardian) - Local Codex Desktop/CLI recovery monitor for long-running tasks. Detects compact failures and context-window overflow, then queues audited handoff bundles.


### PR DESCRIPTION
Adds `ralph-harness` to **Development Tools**.

Why it fits:
- Codex CLI is a primary target.
- Also supports Claude Code and Gemini CLI.
- It is a minimal repo-local scaffold for specs, fresh-context iterations, git hooks, CI gates, and bounded autonomous loops.

Trial command:

```sh
uvx --from git+https://github.com/rxdt/py_ralph_frame ralph-harness demo
```

Related issue: #54