### PR TITLE
Add lore (learnings system for Codex & Claude Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 ### 🧠 Newly Added Agent Skills
 
 - [harmony-next.skills](https://github.com/linhay/harmony-next.skills) by [linhay](https://github.com/linhay) - HarmonyOS NEXT developer skill for Codex and other coding agents, with local ArkTS/ArkUI/API references, DevEco Studio workflows, Emulator/HDC automation, UI/UX audit, trace audit, and Empty Ability smoke-test templates.
+- [lore](https://github.com/aoc81/lore) by [aoc81](https://github.com/aoc81) - Self-maintaining learnings system for Codex & Claude Code. A `UserPromptSubmit` hook auto-recalls relevant past learnings into context and a `Stop` hook nudges capture of only non-obvious, reusable facts, with a freshness linter and a blocking pre-push secret scan. Plain-markdown store committed in your repo; stdlib Python, zero deps, no network.
 
 ### 🛠️ Newly Added MCP Servers
 
@@ -62,6 +63,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 
 - [Agents.md](https://agents.md) - A simple, open format for guiding coding agents, used by over 20k open-source projects.
 - [Codex Skills](https://github.com/openai/skills) - Skills Catalog for Codex
+- [lore](https://github.com/aoc81/lore) by [aoc81](https://github.com/aoc81) - Self-maintaining learnings system for Codex & Claude Code. A `UserPromptSubmit` hook auto-recalls relevant past learnings into context and a `Stop` hook nudges capture of only non-obvious, reusable facts, with a freshness linter and a blocking pre-push secret scan. Plain-markdown store committed in your repo; stdlib Python, zero deps, no network.
 - [Codex Skills](https://github.com/Dimillian/Skills) - Codex Skills by Dimillian
 - [Codex Small Business Skills](https://github.com/simongonzalezdc/codex-small-business-skills) by [Simon Gonzalez De Cruz](https://github.com/simongonzalezdc) - Apache-2.0 Codex port of Anthropic's Small Business skills, with 31 workflows for cash flow, invoices, CRM, support, marketing, hiring, and weekly business rhythm.
 - [AgentSys](https://github.com/avifenesh/agentsys) by [avifenesh](https://github.com/avifenesh) - Workflow automation system for Claude with a group of useful plugins, agents, and skills. Automates task-to-production workflows, PR management, code cleanup, performance investigation, drift detection, and multi-agent code review. Includes [agnix](https://github.com/avifenesh/agnix) for linting agent configurations. Built on thousands of lines of code with thousands of tests. Uses deterministic detection (regex, AST) with LLM judgment for efficiency. Used on many production systems.


### PR DESCRIPTION
Adds **lore** under **Agent Skills › General** (and Newly Added).

- Repo: https://github.com/aoc81/lore
- License: MIT

lore is a self-maintaining learnings system. On Codex (`python3 codex/install.py`), a `UserPromptSubmit` hook auto-recalls relevant past learnings into context and a `Stop` hook nudges capture of only non-obvious, reusable facts, via the shared recall/capture core and the `lore` skill. It ships a freshness linter (flags entries whose referenced code changed) and a blocking pre-push secret scan over the store. Plain-markdown store committed in your repo; stdlib Python, zero deps, no network — works on macOS/Linux/Windows.

Follows the existing `- [Name](url) by [author](url) - desc` format.