### PR TITLE
Add Orca

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 - [agent-sessions](https://github.com/jazzyalex/agent-sessions) - Local-first macOS app for browsing and full-text searching Codex session history alongside other local coding-agent transcripts; resume is available where the underlying CLI supports it.
 - [codexsm](https://github.com/milisp/codexsm) - Codex session manager, Cross platform GUI. rename, view, delete session file. one click resume session
 - [agentbox](https://github.com/madarco/agentbox) - Run multiple Codex (and Claude Code / OpenCode) sessions in parallel, each in its own sandboxed box — local Docker or cloud VMs (Hetzner/Daytona/Vercel/E2B). Sub-1s checkpoint starts, per-box browser + VS Code, and a dashboard to switch between boxes.
+- [Orca](https://onorca.dev) - Desktop IDE that runs Codex CLI and other agents (Claude Code, Cursor, Gemini) in parallel, each in its own git worktree, with built-in terminal and diff review.
 
 ### WebUI & App
 - [happy](https://github.com/slopus/happy) - Mobile and Web client for Codex and Claude Code, with realtime voice, encryption and fully featured


### PR DESCRIPTION
Adds **Orca** to the GUI/App section.

Orca is an open-source (MIT) desktop IDE/ADE that natively runs **Codex CLI** — and other agents like Claude Code, Cursor, and Gemini — each in its own isolated git worktree, with a built-in terminal and diff review. macOS/Windows/Linux + a mobile companion.

- Source: https://github.com/stablyai/orca
- Website: https://onorca.dev

Thanks for maintaining this list!