### PR TITLE
Add opencodex (universal provider proxy for Codex)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 - [async-code](https://github.com/ObservedObserver/async-code) - Use Claude Code / CodeX CLI to perform multiple tasks in parallel with a Codex-style UI. Your personal codex/cursor-background agent. 
 - [cc-switch](https://github.com/farion1231/cc-switch) - A cross-platform desktop All-in-One assistant for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI & Hermes Agent. Only official website: ccswitch.
 - [codex-profiles](https://github.com/Ducksss/codex-profiles) - Switch Codex CLI and Desktop accounts with isolated CODEX_HOME profiles instead of copying auth files by hand.
+- [opencodex](https://github.com/lidge-jun/opencodex) - Universal provider proxy for Codex — use Claude, Gemini, Grok, GLM, DeepSeek, Kimi, Cursor, and more with the Codex CLI/App/SDK, with multi-account pooling and a GUI dashboard.
 - [ruler](https://github.com/intellectronica/ruler) - Ruler — apply the same rules to all coding agents
 - [cc-sdd](https://github.com/gotalab/cc-sdd) - Spec-driven development (SDD) for your team's workflow. High quality commands that enforce structured requirements→design→tasks workflow and steering, transforming how you build with AI. Support Claude Code, Codex, Cursor, Github Copilot, Gemini CLI and Qwen Code.
 - [vibekit](https://github.com/superagent-ai/vibekit) - Run Claude Code, Gemini, Codex — or any coding agent — in a clean, isolated sandbox with sensitive data redaction and observability baked in.


### PR DESCRIPTION
Adds [opencodex](https://github.com/lidge-jun/opencodex) — a universal provider proxy that translates Codex's Responses API so you can drive the Codex CLI/App/SDK with Claude, Gemini, Grok, GLM, DeepSeek, Kimi, Cursor, and more. Includes multi-account pooling and a GUI dashboard.

Actively maintained (npm `@bitkyc08/opencodex` v2.6.20), 233★, ~15k npm downloads in ~3 weeks. Placed under Tools → Development Tools next to similar account/proxy tooling.