### PR TITLE
Add Nika plugin (workflow authoring + oracle) to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 > A workflow is a tightly coupled set of Codex-native resources that facilitate specific projects
 
 - [oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex) - OmX - Oh My codeX: Your codex is not alone. Add hooks, agent teams, HUDs, and so much more.
+- [Nika](https://github.com/supernovae-st/nika-agents) by [Thibaut Melen](https://github.com/ThibautMelen) - Codex plugin for Nika workflows: `/nika:check`, `/nika:explain`, `/nika:new` + authoring skill + read-only MCP oracle — audit `.nika.yaml` DAGs (schema, permits, honest cost floor) before a single token is spent.
 
 ## Tools
 


### PR DESCRIPTION
Adds **nika-agents** — the Codex plugin for Nika workflows (house format).

The plugin ships `/nika:check`, `/nika:explain` and `/nika:new` commands, the authoring skill, and the read-only MCP oracle: repeated AI work becomes a reviewable `.nika.yaml` DAG, audited (schema, permits, honest cost floor) before a single token is spent. The plugin files are drift-gated in CI against the engine (mirror manifest + cron).

Disclosure: I'm the author.
