### PR TITLE
Add GoodMemory MCP memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 - [claude-codex-bridge](https://github.com/jackcongmac/claude-codex-bridge) - Bidirectional MCP bridge for Codex CLI and Claude Code collaboration, with persistent Claude sessions and shared collaboration files.
 - [AccInt](https://github.com/maxbaluev/accreted-intelligence) - Local-first MCP work memory for Codex CLI, Claude Code, OpenCode, and Cursor with scored retrieval, commitment tracking, and outcome-based credit across sessions.
 - [Vestige](https://github.com/samvallad33/vestige) - Local-first cognitive memory MCP server that gives Codex CLI persistent recall across sessions. SQLite storage, FSRS-6 retention with active forgetting so old context decays instead of piling up, prediction-error gating, and hybrid retrieval. Single Rust binary, npm install -g vestige-mcp-server.
+- [GoodMemory](https://github.com/hjqcan/GoodMemory) - Local-first, auditable memory for Codex CLI and Claude Code. `goodmemory setup` installs scoped recall hooks and read-only MCP inspection; SQLite persistence is the default, while optional writeback stays reviewable and reversible.
 
 ### setup tool
 - [codex-1up](https://github.com/regenrek/codex-1up) - equips your Codex CLI coding agent with powerful tools.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,34 @@
-# Awesome Codex CLI 🚀
+# Awesome Codex CLI 🚀 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-[![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 [![Stars](https://img.shields.io/github/stars/milisp/awesome-codex-cli?style=social)](https://github.com/milisp/awesome-codex-cli/stargazers)
 [![Follow on 𝕏](https://img.shields.io/badge/𝕏-@lisp__mi-1c9bf0)](http://x.com/intent/follow?screen_name=lisp_mi)
 [![Subreddit subscribers](https://img.shields.io/reddit/subreddit-subscribers/codex?style=flat&logo=reddit&label=subreddit)](https://www.reddit.com/r/codex/)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zAjtD4kf5K)
 
-A curated list of Agent skill, awesome resources, tools, and tutorials for OpenAI Codex CLI
+A curated list of agent skills, resources, tools, and tutorials for OpenAI Codex CLI.
 
+## Contents
+
+- [What is OpenAI Codex CLI](#what-is-openai-codex-cli)
 - [🆕 Newly Added](#-newly-added)
 - [Agent Skills](#agent-skills)
   - [General](#general)
-- [Workflows & Knowledge Guides](#workflows--knowledge-guides-)
+- [Workflows & Knowledge Guides 🧠](#workflows--knowledge-guides-)
 - [Tools](#tools)
   - [GUI & MCP](#gui--mcp)
+  - [MCP server](#mcp-server)
   - [setup tool](#setup-tool)
   - [Session manager](#session-manager)
   - [WebUI \& App](#webui--app)
   - [Development Tools](#development-tools)
   - [Stat](#stat)
-    - [Editor](#editor)
-    - [Termial](#termial)
-    - [System](#system)
+  - [Editor](#editor)
+  - [Termial](#termial)
+  - [System](#system)
 - [Official Resources](#official-resources)
   - [Documentation](#documentation)
   - [Blog Posts & Tutorials](#blog-posts--tutorials)
-- [GUI & Web Interface Extensions](#gui--web-interface-extensions)
+- [Web Interface Extensions](#web-interface-extensions)
   - [Official Web Interface](#official-web-interface)
   - [IDE Integrations](#ide-integrations)
 - [Use Cases](#use-cases)
@@ -35,24 +38,17 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
   - [Discussions](#discussions)
   - [Learning Resources](#learning-resources)
   - [Community Projects](#community-projects)
-- [Contributing](#contributing)
-- [License](#license)
+- [Growing thanks to you](#growing-thanks-to-you)
 
-## What is OpenAI Codex CLI?
+## What is OpenAI Codex CLI
 
-- [OpenAI Codex CLI](https://github.com/openai/codex) is Lightweight coding agent that runs in your terminal
-- [codexia](https://github.com/milisp/codexia) - Agent workstation for Codex CLI and Claude Code
+OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
+[Codexia](https://github.com/milisp/codexia) is an agent workstation for Codex CLI and Claude Code.
 
 ## 🆕 Newly Added
 
 > 🚀 **Want your Server/Skill featured inside the Codexia Desktop App?**
-> Submit a PR to our main repo [milisp/codexia](https://github.com/milisp/codexia) to add it directly to the built-in Marketplace!
-
-### 🧠 Newly Added Agent Skills
-
-- [harmony-next.skills](https://github.com/linhay/harmony-next.skills) by [linhay](https://github.com/linhay) - HarmonyOS NEXT developer skill for Codex and other coding agents, with local ArkTS/ArkUI/API references, DevEco Studio workflows, Emulator/HDC automation, UI/UX audit, trace audit, and Empty Ability smoke-test templates.
-
-### 🛠️ Newly Added MCP Servers
+> Submit a PR to the main Codexia repository to add it directly to the built-in marketplace.
 
 ## Agent Skills
 
@@ -61,11 +57,11 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 ### General
 
 - [Agents.md](https://agents.md) - A simple, open format for guiding coding agents, used by over 20k open-source projects.
-- [Codex Skills](https://github.com/openai/skills) - Skills Catalog for Codex
-- [Codex Skills](https://github.com/Dimillian/Skills) - Codex Skills by Dimillian
+- [Codex Skills](https://github.com/openai/skills) - A catalog of reusable skills for Codex.
+- [Codex Skills](https://github.com/Dimillian/Skills) - A skill collection maintained by Dimillian.
 - [Codex Small Business Skills](https://github.com/simongonzalezdc/codex-small-business-skills) by [Simon Gonzalez De Cruz](https://github.com/simongonzalezdc) - Apache-2.0 Codex port of Anthropic's Small Business skills, with 31 workflows for cash flow, invoices, CRM, support, marketing, hiring, and weekly business rhythm.
 - [AgentSys](https://github.com/avifenesh/agentsys) by [avifenesh](https://github.com/avifenesh) - Workflow automation system for Claude with a group of useful plugins, agents, and skills. Automates task-to-production workflows, PR management, code cleanup, performance investigation, drift detection, and multi-agent code review. Includes [agnix](https://github.com/avifenesh/agnix) for linting agent configurations. Built on thousands of lines of code with thousands of tests. Uses deterministic detection (regex, AST) with LLM judgment for efficiency. Used on many production systems.
-- [AI Agent, AI Spy](https://youtu.be/0ANECpNdt-4) by [Whittaker & Tiwari](https://signalfoundation.org/) - Members from the Signal Foundation with some really great tips and tricks on how to turn your operating system into an instrument of total surveillance, and why some companies are doing this really awesome thing. [warning: YouTube link].
+- [AI Agent, AI Spy](https://youtu.be/0ANECpNdt-4) by [Whittaker & Tiwari](https://signalfoundation.org/) - Members from the Signal Foundation with some really great tips and tricks on how to turn your operating system into an instrument of total surveillance, and why some companies are doing this really awesome thing (YouTube link).
 - [cc-devops-skills](https://github.com/akin-ozer/cc-devops-skills) by [akin-ozer](https://github.com/akin-ozer) - A practical agent skill pack for DevOps work in Claude Code and Codex.
 - [Claude Codex Settings](https://github.com/fcakyon/claude-codex-settings) by [fatih akyon](https://github.com/fcakyon) - A well-organized, well-written set of plugins covering core developer activities, such as working with common cloud platforms like GitHub, Azure, MongoDB, and popular services such as Tavily, Playwright, and more. Clear, not overly-opinionated, and compatible with a few other providers.
 - [harmony-next.skills](https://github.com/linhay/harmony-next.skills) by [linhay](https://github.com/linhay) - HarmonyOS NEXT developer skill for Codex and other coding agents, with local ArkTS/ArkUI/API references, DevEco Studio workflows, Emulator/HDC automation, UI/UX audit, trace audit, and Empty Ability smoke-test templates.
@@ -92,11 +88,13 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 ## Tools
 
 ### GUI & MCP
-- [codexia-zen](https://github.com/milisp/codexia-zen) - a minimalist design GUI for OpenAI Codex CLI
-- [MCP Linker](https://github.com/milisp/mcp-linker) - GUI for managing MCP configs for Codex CLI
+
+- [codexia-zen](https://github.com/milisp/codexia-zen) - A minimalist design GUI for OpenAI Codex CLI.
+- [MCP Linker](https://github.com/milisp/mcp-linker) - GUI for managing MCP configs for Codex CLI.
 - [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data extraction skill & MCP server for AI coding agents. 20 tools: followers, tweets, replies, mentions, lists, hashtags, spaces & more.
 
 ### MCP server
+
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - MCP server that generates app icons, favicons, OG images, logos, and wordmarks by routing requests across 30+ image generation models. Zero API key needed on first run via free-tier providers.
 - [ejentum-mcp](https://github.com/ejentum/ejentum-mcp)
 - [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) - Auto-wrap any Python Click/Typer CLI as an MCP server. Zero-code transformation that introspects CLI commands and exposes them as MCP tools. Works with Codex CLI, Claude Code, and any MCP client. `pip install click-to-mcp` - Reasoning Harness MCP server. Library of 679 cognitive operations engineered in natural language across four harnesses (reasoning, code, anti-deception, memory). Each call retrieves a task-matched scaffold (failure pattern, procedure, suppression vectors, falsification test) the agent ingests before responding. Free tier 100 calls.
@@ -106,60 +104,64 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 - [GoodMemory](https://github.com/hjqcan/GoodMemory) - Local-first, auditable memory for Codex CLI and Claude Code. `goodmemory setup` installs scoped recall hooks and read-only MCP inspection; SQLite persistence is the default, while optional writeback stays reviewable and reversible.
 
 ### setup tool
-- [codex-1up](https://github.com/regenrek/codex-1up) - equips your Codex CLI coding agent with powerful tools.
-- [codex-universal](https://github.com/openai/codex-universal) - Base docker image used in Codex environments
+
+- [codex-1up](https://github.com/regenrek/codex-1up) - Equips your Codex CLI coding agent with powerful tools.
+- [codex-universal](https://github.com/openai/codex-universal) - Base Docker image used in Codex environments.
 
 ### Session manager
-- [crystal](https://github.com/stravu/crystal) - Run multiple Codex and Claude Code AI sessions in parallel git worktrees. Test, compare approaches & manage AI-assisted development workflows in one desktop app.
-- [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running Codex CLI, Claude Code, and Gemini CLI agents side by side in separate git worktrees.
-- [vibe-kanban](https://github.com/BloopAI/vibe-kanban) - Kanban board to manage your AI coding agents
-- [ccmanager](https://github.com/kbwo/ccmanager) - Coding Agent Session Manager that supports Claude Code / Gemini CLI / Codex CLI / Cursor Agent / Copilot CLI
-- [codmate](https://github.com/loocor/codmate) - a macOS SwiftUI app for managing CLI AI sessions
+
+- [crystal](https://github.com/stravu/crystal) - Run multiple Codex and Claude Code AI sessions in parallel Git worktrees. Test, compare approaches & manage AI-assisted development workflows in one desktop app.
+- [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running Codex CLI, Claude Code, and Gemini CLI agents side by side in separate Git worktrees.
+- [vibe-kanban](https://github.com/BloopAI/vibe-kanban) - Kanban board to manage your AI coding agents.
+- [ccmanager](https://github.com/kbwo/ccmanager) - Coding Agent Session Manager that supports Claude Code / Gemini CLI / Codex CLI / Cursor Agent / Copilot CLI.
+- [codmate](https://github.com/loocor/codmate) - A macOS SwiftUI app for managing CLI AI sessions.
 - [agent-sessions](https://github.com/jazzyalex/agent-sessions) - Local-first macOS app for browsing and full-text searching Codex session history alongside other local coding-agent transcripts; resume is available where the underlying CLI supports it.
 - [cctop](https://github.com/st0012/cctop) - Keyboard-first macOS menubar monitor for Codex CLI sessions. Shows which runs are working, waiting, or need approval, jumps back to the exact terminal pane, and also supports Codex Desktop, Claude Code, opencode, and pi.
-- [codexsm](https://github.com/milisp/codexsm) - Codex session manager, Cross platform GUI. rename, view, delete session file. one click resume session
+- [codexsm](https://github.com/milisp/codexsm) - Codex session manager, cross-platform GUI. Rename, view, or delete session files, with one-click session resume.
 - [agentbox](https://github.com/madarco/agentbox) - Run multiple Codex (and Claude Code / OpenCode) sessions in parallel, each in its own sandboxed box — local Docker or cloud VMs (Hetzner/Daytona/Vercel/E2B). Sub-1s checkpoint starts, per-box browser + VS Code, and a dashboard to switch between boxes.
-- [Orca](https://onorca.dev) - Desktop IDE that runs Codex CLI and other agents (Claude Code, Cursor, Gemini) in parallel, each in its own git worktree, with built-in terminal and diff review.
+- [Orca](https://onorca.dev) - Desktop IDE that runs Codex CLI and other agents (Claude Code, Cursor, Gemini) in parallel, each in its own Git worktree, with built-in terminal and diff review.
 
 ### WebUI & App
-- [happy](https://github.com/slopus/happy) - Mobile and Web client for Codex and Claude Code, with realtime voice, encryption and fully featured
-- [CodexMonitor](https://github.com/Dimillian/CodexMonitor) - An app to monitor the (Codex) situation
-- [CodexFlow](https://github.com/lulu-sk/CodexFlow) - CodexFlow is an enhanced GUI tool designed for Codex CLI, focused on improving conversation management and interaction.
-- [Codex-webui](https://github.com/harryneopotter/Codex-webui) - A minimal webui to run Codex-CLI locally with a UI, session resume and persistent memory (Un-official)
-- [AionUi](https://github.com/iOfficeAI/AionUi) - Free, local, open-source GUI app for Gemini CLI — Better Chat UI, File Management, AI image editing, multi-agent support, multi-LLMs
-- [Untether](https://github.com/littlebearapps/untether) - Telegram bridge for Codex CLI (and 5 other agents). Send tasks by voice, stream progress, toggle approval policy (full auto/safe) via inline buttons
-- [IM.codes](https://github.com/im4codes/imcodes) - The IM for agents: a mobile/web control layer for Codex CLI and other terminal-based coding agents, with terminal access, file browsing, git views, localhost preview, notifications, and multi-agent workflows.
+
+- [happy](https://github.com/slopus/happy) - Mobile and Web client for Codex and Claude Code, with real-time voice and encryption.
+- [CodexMonitor](https://github.com/Dimillian/CodexMonitor) - An app to monitor the Codex situation.
+- [CodexFlow](https://github.com/lulu-sk/CodexFlow) - An enhanced GUI tool designed for Codex CLI, focused on improving conversation management and interaction.
+- [Codex-webui](https://github.com/harryneopotter/Codex-webui) - A minimal web UI to run Codex CLI locally with a UI, session resume, and persistent memory (unofficial).
+- [AionUi](https://github.com/iOfficeAI/AionUi) - Free, local, open-source GUI app for Gemini CLI — Better Chat UI, File Management, AI image editing, multi-agent support, multi-LLMs.
+- [Untether](https://github.com/littlebearapps/untether) - Telegram bridge for Codex CLI (and 5 other agents). Send tasks by voice, stream progress, toggle approval policy (full auto/safe) via inline buttons.
+- [IM.codes](https://github.com/im4codes/imcodes) - The IM for agents: a mobile/web control layer for Codex CLI and other terminal-based coding agents, with terminal access, file browsing, Git views, localhost preview, notifications, and multi-agent workflows.
 - [Onepilot](https://onepilotapp.com) - Native iOS SSH terminal for Codex CLI and Claude Code. Full PTY, GitHub integration, localhost forwarding, live file editing, and one-click AI agent deployment via OpenClaw. [App Store](https://apps.apple.com/app/onepilot-ai-terminal/id6743826919).
 - [ToutKit](https://github.com/toutkit/toutkit) - Desktop notebook with a built-in terminal that runs Codex CLI alongside Claude Code and Gemini; an in-app webview renders whatever the agent writes inline, and each note is a self-contained folder with its own SQLite, files, and scripts. Local-first, Electron, AGPL-3.0.
 - [Codex on Telegram](https://github.com/leoshenzh/codex-on-telegram) - Self-hosted macOS bridge that drives your local Codex CLI (or Claude Code) sessions from Telegram. Attach to a session already running on your machine, approve permission prompts in chat, run per-topic parallel sessions, and resume the same session after a restart.
 - [Agent Island](https://github.com/tristan666666/agent-island) - Native macOS notch companion for Claude/Codex sessions. Shows running / your turn / stuck state in the notch and can auto-resume a selected long-running session after the limit window resets.
 
 ### Development Tools
+
 - [humanlayer](https://github.com/humanlayer/humanlayer) - The best way to get AI coding agents to solve hard problems in complex codebases.
-- [ralph-harness](https://github.com/rxdt/py_ralph_frame) - Minimal repo-local loop scaffold for Codex CLI, Claude Code, and Gemini CLI. Uses `PROMPT.md`, specs, fresh-context iterations, git hooks, CI verification, and hard iteration/time caps so agents make small gated commits instead of drifting in one long chat.
+- [ralph-harness](https://github.com/rxdt/py_ralph_frame) - Minimal repo-local loop scaffold for Codex CLI, Claude Code, and Gemini CLI. Uses `PROMPT.md`, specs, fresh-context iterations, Git hooks, CI verification, and hard iteration/time caps so agents make small gated commits instead of drifting in one long chat.
 - [Hephaestus](https://github.com/agentlas-ai/Hephaestus) - Open Agent OS for Claude Code, Codex, and Cursor: meta-agent builder, A2A Hub routing, local ontology, and memory/security gates.
 - [Agent FM](https://github.com/agentfm-ai/agent-fm) - Local macOS app for listening to Claude Code and Codex agents, with Global Mix, blocker alerts, and BYOK narration.
 - [Relay Baton](https://github.com/guorunjie/codex-relay-baton-guardian) - Local Codex Desktop/CLI recovery monitor for long-running tasks. Detects compact failures and context-window overflow, then queues audited handoff bundles.
 - [EchoCoding](https://github.com/launsion-boop/EchoCoding) - Audio layer for Codex CLI with hook-triggered SFX, ambient soundscape, and optional cloud TTS/ASR voice interaction.
 - [unslop](https://github.com/MohamedAbdallah-14/unslop) - CLI and MCP server that removes AI writing patterns from agent-generated text. Works with Codex, Claude Code, Gemini CLI, and Cursor. Five intensity levels and lint-only audit mode.
 - [brooks-lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books — decay risk diagnostics with book citations, severity labels, and four analysis modes (PR review, architecture audit, tech debt, test quality).
-- [Claudable](https://github.com/opactorai/Claudable) - Claudable is an open-source web builder that leverages local CLI agents, such as Claude Code, Codex, Gemini CLI, Qwen Code, and Cursor Agent, to build and deploy products effortlessly.
+- [Claudable](https://github.com/opactorai/Claudable) - An open-source web builder that leverages local CLI agents, such as Claude Code, Codex, Gemini CLI, Qwen Code, and Cursor Agent, to build and deploy products effortlessly.
 - [claude-squad](https://github.com/smtg-ai/claude-squad) - Manage multiple AI terminal agents like Claude Code, Aider, Codex, OpenCode, and Amp.
 - [async-code](https://github.com/ObservedObserver/async-code) - Use Claude Code / CodeX CLI to perform multiple tasks in parallel with a Codex-style UI. Your personal codex/cursor-background agent. 
 - [cc-switch](https://github.com/farion1231/cc-switch) - A cross-platform desktop All-in-One assistant for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI & Hermes Agent. Only official website: ccswitch.
 - [codex-profiles](https://github.com/Ducksss/codex-profiles) - Switch Codex CLI and Desktop accounts with isolated CODEX_HOME profiles instead of copying auth files by hand.
 - [opencodex](https://github.com/lidge-jun/opencodex) - Universal provider proxy for Codex — use Claude, Gemini, Grok, GLM, DeepSeek, Kimi, Cursor, and more with the Codex CLI/App/SDK, with multi-account pooling and a GUI dashboard.
-- [ruler](https://github.com/intellectronica/ruler) - Ruler — apply the same rules to all coding agents
-- [cc-sdd](https://github.com/gotalab/cc-sdd) - Spec-driven development (SDD) for your team's workflow. High quality commands that enforce structured requirements→design→tasks workflow and steering, transforming how you build with AI. Support Claude Code, Codex, Cursor, Github Copilot, Gemini CLI and Qwen Code.
+- [ruler](https://github.com/intellectronica/ruler) - Applies the same rules to all coding agents.
+- [cc-sdd](https://github.com/gotalab/cc-sdd) - Spec-driven development (SDD) for your team's workflow. High quality commands that enforce structured requirements→design→tasks workflow and steering, transforming how you build with AI. Support Claude Code, Codex, Cursor, GitHub Copilot, Gemini CLI and Qwen Code.
 - [vibekit](https://github.com/superagent-ai/vibekit) - Run Claude Code, Gemini, Codex — or any coding agent — in a clean, isolated sandbox with sensitive data redaction and observability baked in.
 - [dotai](https://github.com/udecode/dotai) - Context Manager for Claude Code Plugins + Codex + Cursor.
-- [zcf](https://github.com/UfoMiao/zcf) - Zero-config, one-click setup for Claude Code & Codex with bilingual support, intelligent agent system and personalized AI assistant
+- [zcf](https://github.com/UfoMiao/zcf) - Zero-config, one-click setup for Claude Code & Codex with bilingual support, intelligent agent system and personalized AI assistant.
 - [vsync](https://github.com/nicepkg/vsync) - Sync Skills, MCP servers, Agents & Commands across Claude Code, Cursor, OpenCode, and Codex with automatic format conversion (JSON ↔ TOML ↔ JSONC).
 - [Bring Your AI](https://bringyour.ai/claude-code-to-codex) - Local-first Claude Code to Codex migration tool that keeps harness files local, maps AGENTS.md / CLAUDE.md guidance, MCP config, and skills, and records non-equivalent hooks as validation notes.
-- [just-every/code](https://github.com/just-every/code) - fork of openai/codex focused on real developer ergonomics: Browser integration, multi-agents, theming, and reasoning control — all while staying compatible with upstream.
+- [just-every/code](https://github.com/just-every/code) - A fork of OpenAI Codex focused on real developer ergonomics: Browser integration, multi-agents, theming, and reasoning control — all while staying compatible with upstream.
 - [agnix](https://github.com/avifenesh/agnix) - Linter for AI agent configurations. Validates AGENTS.md, .codex/config.toml, skills, hooks, and MCP configs with 156 rules, auto-fix, and editor integration.
 - [caliber](https://github.com/rely-ai-org/caliber) - CLI that fingerprints your codebase and generates AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md, skills, MCPs) for Claude Code, Cursor, and Codex. Scores your setup 0–100.
-- [bernstein](https://github.com/chernistry/bernstein) - Parallel multi-agent orchestrator — spawns Codex CLI, Claude Code, and Gemini CLI simultaneously on isolated git worktrees, verifies with tests, auto-commits working code. Zero LLM tokens on coordination.
+- [bernstein](https://github.com/chernistry/bernstein) - Parallel multi-agent orchestrator — spawns Codex CLI, Claude Code, and Gemini CLI simultaneously on isolated Git worktrees, verifies with tests, auto-commits working code. Zero LLM tokens on coordination.
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence.
 - [TokRepo](https://github.com/henu-wang/tokrepo) - Canonical GitHub landing page for the TokRepo open registry, with links to a Codex-compatible skill repo, MCP server, and installable AI assets such as prompts, workflows, and MCP configs.
 - [VideoOverlayKit](https://github.com/alichherawalla/video-overlay-kit) - MCP server that renders 4-6s animated b-roll overlay videos (mp4) for short-form social (LinkedIn, IG Reels, YouTube Shorts, TikTok). Paste your script into Codex CLI / Claude Code / Cursor, the model writes the scene spec and renders the mp4. Built on Remotion + Tabler + Lottie. Free, MIT, local.
@@ -167,96 +169,102 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 - [10000 Mentors Research Workflow](https://github.com/wd041216-bit/10000-mentors-research-workflow) - Codex-native autonomous research loop with source-gated mentor critique, submission-advisor reflection, bounded execution, and GitHub delivery.
 - [SwarmVault](https://github.com/swarmclawai/swarmvault) - Local-first RAG knowledge base compiler. Turns raw docs, research, and code into a persistent markdown wiki, knowledge graph, and hybrid SQLite FTS + embeddings search. Ships a bundled skill and MCP server; works with Codex CLI, Claude Code, and OpenCode.
 - [SwarmClaw](https://github.com/swarmclawai/swarmclaw) - Self-hosted multi-agent runtime that delegates to Codex CLI alongside Claude Code, Gemini CLI, OpenCode, Copilot CLI, Cursor Agent, Goose, Qwen Code, and Droid. Org chart view, schedules, runtime skills, persistent memory, and reviewed conversation-to-skill learning. MCP-native (server and client). Electron desktop app, CLI, and Docker.
-- [Alfred](https://github.com/luminik-io/alfred-os) - Self-hosted runtime that turns scoped GitHub issues into reviewed pull requests through autonomous Codex CLI and Claude Code agents. Per-firing git worktrees, label-driven state machine (agent:implement → agent:in-flight → agent:pr-open → agent:done), role-based engine routing across Codex and Claude, and Slack reporting. Python, MIT, macOS/Linux.
+- [Alfred](https://github.com/luminik-io/alfred-os) - Self-hosted runtime that turns scoped GitHub issues into reviewed pull requests through autonomous Codex CLI and Claude Code agents. Per-firing Git worktrees, label-driven state machine (agent:implement → agent:in-flight → agent:pr-open → agent:done), role-based engine routing across Codex and Claude, and Slack reporting. Python, MIT, macOS/Linux.
 - [Codex First Task Prompt Generator](https://ronnie2025.github.io/ai-agent-workbench-starter-pack/codex-first-task-prompt-generator.html) - Free web tool that turns a Codex CLI project goal into a scoped first-task prompt with constraints and acceptance checks.
 
 ### Stat
+
 - [ccusage](https://github.com/ryoppippi/ccusage) - A CLI tool for analyzing Claude Code/Codex CLI usage from local JSONL files.
 - [ax](https://github.com/Necmttn/ax) - Local-first telemetry and memory graph for Codex CLI, Claude Code, OpenCode, Cursor, and Pi histories with cost analytics, skill/hook usage, workflow extraction, dashboard, and MCP access.
 - [CodexBar](https://github.com/steipete/CodexBar) - Show usage stats for OpenAI Codex and Claude Code, without having to login.
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - Local TUI for inspecting AI coding-agent session logs, usage, cost, latency, tool failures, diffs, and CI gates.
 - [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) - Windows tray app for monitoring Claude Code and Codex token usage, costs, sessions, and rate limits from local JSONL logs.
 
-#### Editor
+### Editor
+
 - [zed](https://github.com/zed-industries/zed) - Code at the speed of thought – Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.
 
-#### Termial
-- [ghostty](https://github.com/ghostty-org/ghostty) - 👻 Ghostty is a fast, feature-rich, and cross-platform terminal emulator that uses platform-native UI and GPU acceleration.
-- [Tmux](https://github.com/tmux/tmux) - tmux source code
+### Termial
 
-#### System
-- [omarchy](https://github.com/basecamp/omarchy) - Opinionated Arch/Hyprland Setup
- 
+- [ghostty](https://github.com/ghostty-org/ghostty) - 👻 Ghostty is a fast, feature-rich, and cross-platform terminal emulator that uses platform-native UI and GPU acceleration.
+- [Tmux](https://github.com/tmux/tmux) - Source code for the terminal multiplexer.
+
+### System
+
+- [omarchy](https://github.com/basecamp/omarchy) - Opinionated Arch/Hyprland setup.
+
 ## Official Resources
 
 ### Documentation
-- [OpenAI Codex CLI Getting Started](https://help.openai.com/en/articles/11096431-openai-codex-cli-getting-started) - Official getting started guide
-- [GitHub Repository](https://github.com/openai/codex) - Official OpenAI Codex CLI repository
-- [OpenAI Codex Overview](https://openai.com/codex/) - Product overview and features
+
+- [OpenAI Codex CLI Getting Started](https://help.openai.com/en/articles/11096431-openai-codex-cli-getting-started) - Official getting started guide.
+- [GitHub Repository](https://github.com/openai/codex) - Official OpenAI Codex CLI repository.
+- [OpenAI Codex Overview](https://openai.com/codex/) - Product overview and features.
 
 ### Blog Posts & Tutorials
-- [DataCamp Tutorial](https://www.datacamp.com/tutorial/open-ai-codex-cli-tutorial) - Comprehensive tutorial on using Codex CLI
-- [Blott Studio Guide](https://www.blott.studio/blog/post/openai-codex-cli-build-faster-code-right-from-your-terminal) - Build faster code from your terminal
-- [Medium Tutorial](https://medium.com/ai-software-engineer/how-to-install-and-use-openai-codex-cli-in-2-minutes-29e9fdd0e8c5) - Quick 2-minute setup guide
-- [OpenReplay Integration Guide](https://blog.openreplay.com/integrate-openais-codex-cli-tool-development-workflow/) - How to integrate Codex CLI into your development workflow
+
+- [DataCamp Tutorial](https://www.datacamp.com/tutorial/open-ai-codex-cli-tutorial) - Comprehensive tutorial on using Codex CLI.
+- [Blott Studio Guide](https://www.blott.studio/blog/post/openai-codex-cli-build-faster-code-right-from-your-terminal) - Build faster code from your terminal.
+- [Medium Tutorial](https://medium.com/ai-software-engineer/how-to-install-and-use-openai-codex-cli-in-2-minutes-29e9fdd0e8c5) - Quick 2-minute setup guide.
+- [OpenReplay Integration Guide](https://blog.openreplay.com/integrate-openais-codex-cli-tool-development-workflow/) - How to integrate Codex CLI into your development workflow.
 
 ## Web Interface Extensions
 
 ### Official Web Interface
-- [Codex](https://chatgpt.com/codex) - Official cloud-based agent with web interface
+
+- [Codex](https://chatgpt.com/codex) - Official cloud-based agent with web interface.
 - Cloud Codex - Sandbox environments preloaded with repositories (ChatGPT Pro/Enterprise/Team/Plus users)
 
 ### IDE Integrations
-- **[Codex VS Code Extension](https://marketplace.visualstudio.com/items?itemName=openai.chatgpt)**: Codex is OpenAI's coding agent that helps you write, review, and ship code faster. Use it side-by-side in your IDE or delegate larger tasks to the cloud.
-- **[Codexia VS Code Extension](https://github.com/milisp/codexia-vscode)**: A VS Code extension that provides a chat interface for the OpenAI Codex CLI, allowing you to interact with AI coding assistants directly from your editor.
+
+- [Codex VS Code Extension](https://marketplace.visualstudio.com/items?itemName=openai.chatgpt) - Codex is OpenAI's coding agent that helps you write, review, and ship code faster. Use it side-by-side in your IDE or delegate larger tasks to the cloud.
+- [Codexia VS Code Extension](https://github.com/milisp/codexia-vscode) - A VS Code extension that provides a chat interface for the OpenAI Codex CLI, allowing you to interact with AI coding assistants directly from your editor.
 
 ## Use Cases
 
 ### Development Tasks
-- **Refactoring**: Modernize legacy code and improve structure.
-- **Testing**: Generate comprehensive test suites.
-- **Bug Fixes**: Identify and resolve issues quickly.
-- **Documentation**: Generate and maintain code documentation.
-- **Feature Development**: Scaffold new features and components.
+
+Common development tasks include refactoring legacy code, generating test suites,
+fixing bugs, maintaining documentation, and scaffolding features.
 
 ### Specialized Tasks
-- **Frontend Development**: React components, CSS generation, responsive designs.
-- **Data Analysis**: Dataset exploration, Python scripting, ML projects.
-- **Code Understanding**: Legacy code analysis and architecture insights.
+
+Specialized tasks include frontend development, data analysis, and understanding
+legacy code and architecture.
 
 ---
 
 ## Community
 
 ### Discussions
-- [Hacker News Discussion](https://news.ycombinator.com/item?id=43708025) - Community reactions and experiences
-- [Machine Learning Mastery](https://machinelearningmastery.com/understanding-openai-codex-cli-commands/) - Understanding CLI commands
+
+- [Hacker News Discussion](https://news.ycombinator.com/item?id=43708025) - Community reactions and experiences.
+- [Machine Learning Mastery](https://machinelearningmastery.com/understanding-openai-codex-cli-commands/) - Understanding CLI commands.
 
 ### Learning Resources
-- [Apidog Blog](https://apidog.com/blog/openai-codex-cli/) - Open source coding agent overview
-- Community tutorials and examples (contribute yours!)
+
+- [Apidog Blog](https://apidog.com/blog/openai-codex-cli/) - Open source coding agent overview.
+
+Community tutorials and examples are welcome.
 
 ### Community Projects
-- **[Plux](https://github.com/milisp/plux)** - AI finder/explorer with visual file tree.
-- **[awesome-claude-dxt](https://github.com/milisp/awesome-claude-dxt)** - Curated list of Claude Desktop Extensions.
-- **[awesome-gpt-oss](https://github.com/milisp/awesome-gpt-oss)** - Curated GPT open-source resources.
-- **[awesome-chatgpt-claude-agents](https://github.com/milisp/awesome-chatgpt-claude-agents)** - Collection of awesome agents and AI development tools.
+
+- [Plux](https://github.com/milisp/plux) - AI finder/explorer with visual file tree.
+- [awesome-claude-dxt](https://github.com/milisp/awesome-claude-dxt) - Curated list of Claude Desktop Extensions.
+- [awesome-gpt-oss](https://github.com/milisp/awesome-gpt-oss) - Curated GPT open-source resources.
+- [awesome-chatgpt-claude-agents](https://github.com/milisp/awesome-chatgpt-claude-agents) - Collection of awesome agents and AI development tools.
 
 ---
 
 ## Contributing
 
 Contributions are welcome! Please:
+
 1. Read the [contribution guidelines](contributing.md).
 2. Check existing resources to avoid duplicates.
 3. Ensure links are working and relevant.
 4. Submit a pull request with clear descriptions.
 
 ## Growing thanks to you
+
 [![Stargazers over time](https://starchart.cc/milisp/awesome-codex-cli.svg?variant=adaptive)](https://starchart.cc/milisp/awesome-codex-cli)
-
-## License
-
-[![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
-
-To the extent possible under law, the contributors have waived all copyright and related or neighboring rights to this work.


### PR DESCRIPTION
## Summary

Adds GoodMemory under **Tools > MCP server**, alongside the existing local-first memory entries.

GoodMemory is a local-first, auditable memory layer for Codex CLI and Claude Code. Its setup command installs scoped recall hooks and read-only MCP inspection, SQLite persistence is the default, and optional writeback remains reviewable and reversible.

Project: https://github.com/hjqcan/GoodMemory

At the maintainer’s request, this PR also cleans up the existing README so it conforms to the Awesome list rules: badge placement, synchronized table of contents, list-item formatting, punctuation/casing, duplicate links, and the forbidden license section. The repository LICENSE file remains unchanged.

I read `contributing.md` and starred this repository as requested.

## Validation

- `npx --yes awesome-lint` — passes with 0 errors and 0 warnings
- `git diff --check` — passes
- GoodMemory project URL returns HTTP 200
- Confirmed there is no duplicate GoodMemory entry or PR
