### PR TITLE
Add Codex Skins (one-click themes for the Codex desktop app)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 - [codexia-zen](https://github.com/milisp/codexia-zen) - a minimalist design GUI for OpenAI Codex CLI
 - [MCP Linker](https://github.com/milisp/mcp-linker) - GUI for managing MCP configs for Codex CLI
 - [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data extraction skill & MCP server for AI coding agents. 20 tools: followers, tweets, replies, mentions, lists, hashtags, spaces & more.
+- [Codex Skins](https://codexskins.org) - One-click wallpaper/theme gallery for the OpenAI Codex desktop app. Reversible full-window CDP theme injection, macOS/Windows. Open-source engine (MIT).
 
 ### MCP server
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - MCP server that generates app icons, favicons, OG images, logos, and wordmarks by routing requests across 30+ image generation models. Zero API key needed on first run via free-tier providers.


### PR DESCRIPTION
Adds [Codex Skins](https://codexskins.org) under Tools → GUI & MCP.

One-click wallpaper/theme gallery for the OpenAI Codex desktop app. Full-window theming via CDP injection, fully reversible (no binary patching), macOS & Windows. Built on the open-source, MIT-licensed Codex-Dream-Skin engine.

Placed alphabetically-agnostic at the end of the GUI & MCP list to match existing style.