### PR TITLE
Add Claudexor to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 
 ### Development Tools
 - [humanlayer](https://github.com/humanlayer/humanlayer) - The best way to get AI coding agents to solve hard problems in complex codebases.
+- [Claudexor](https://github.com/razzant/claudexor) - Local-first control plane that runs Codex alongside Claude Code, Cursor, and OpenCode, with profile-aware quota routing, best-of-N runs, and cross-family review.
 - [ralph-harness](https://github.com/rxdt/py_ralph_frame) - Minimal repo-local loop scaffold for Codex CLI, Claude Code, and Gemini CLI. Uses `PROMPT.md`, specs, fresh-context iterations, git hooks, CI verification, and hard iteration/time caps so agents make small gated commits instead of drifting in one long chat.
 - [Hephaestus](https://github.com/agentlas-ai/Hephaestus) - Open Agent OS for Claude Code, Codex, and Cursor: meta-agent builder, A2A Hub routing, local ontology, and memory/security gates.
 - [Agent FM](https://github.com/agentfm-ai/agent-fm) - Local macOS app for listening to Claude Code and Codex agents, with Global Mix, blocker alerts, and BYOK narration.


### PR DESCRIPTION
## Summary

Adds Claudexor to the Development Tools section.

## Codex CLI relevance

Claudexor runs Codex as a first-class harness alongside Claude Code, Cursor, and OpenCode. Its Codex integration includes isolated credential profiles, quota-aware routing, MCP/plugin wiring, best-of-N execution, and cross-family review.

## Project

https://github.com/razzant/claudexor

## Validation

- Active release: v3.0.2
- MIT licensed
- Checked the README and existing PRs for duplicates
- Ran `git diff --check`
