### PR TITLE
Add Korean AGENTS.md practical guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ A curated list of Agent skill, awesome resources, tools, and tutorials for OpenA
 
 > A workflow is a tightly coupled set of Codex-native resources that facilitate specific projects
 
+- [AGENTS.md Practical Guide (Korean)](https://github.com/soul-sol/agents-md-guide-ko) by [soul-sol](https://github.com/soul-sol) - Korean guide to Codex instruction discovery, nested overrides, repository boundaries, completion criteria, and ready-to-use single-service, monorepo, and library examples.
 - [oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex) - OmX - Oh My codeX: Your codex is not alone. Add hooks, agent teams, HUDs, and so much more.
 - [Nika](https://github.com/supernovae-st/nika-agents) by [Thibaut Melen](https://github.com/ThibautMelen) - Codex plugin for Nika workflows: `/nika:check`, `/nika:explain`, `/nika:new` + authoring skill + read-only MCP oracle — audit `.nika.yaml` DAGs (schema, permits, honest cost floor) before a single token is spent.
 


### PR DESCRIPTION
## Summary

- add a free Korean practical guide to the `Workflows & Knowledge Guides` section
- cover Codex instruction discovery, nested overrides, repository boundaries, completion criteria, and three ready-to-use examples
- keep the entry neutral and link only to the free public guide

## Why it fits

The repository describes this section as Codex-native workflows and knowledge guides. This resource focuses specifically on writing and validating repository `AGENTS.md` instructions for Codex.

## Validation

- source link and author profile return HTTP 200
- no existing guide URL or duplicate entry was found
- `git diff --check` passes
- the required repository star is present
- repo-wide `awesome-lint` still reports pre-existing README issues, but no diagnostic points to the added line

Disclosure: I maintain the linked guide.