### PR TITLE
Add Skim to WebUI & App

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 - [ToutKit](https://github.com/toutkit/toutkit) - Desktop notebook with a built-in terminal that runs Codex CLI alongside Claude Code and Gemini; an in-app webview renders whatever the agent writes inline, and each note is a self-contained folder with its own SQLite, files, and scripts. Local-first, Electron, AGPL-3.0.
 - [Codex on Telegram](https://github.com/leoshenzh/codex-on-telegram) - Self-hosted macOS bridge that drives your local Codex CLI (or Claude Code) sessions from Telegram. Attach to a session already running on your machine, approve permission prompts in chat, run per-topic parallel sessions, and resume the same session after a restart.
 - [Agent Island](https://github.com/tristan666666/agent-island) - Native macOS notch companion for Claude/Codex sessions. Shows running / your turn / stuck state in the notch and can auto-resume a selected long-running session after the limit window resets.
+- [Skim](https://skim.md) - Free, open-source Chrome/Firefox extension that live-renders markdown files, including Codex CLI's plans and reports, in the browser. Math, Mermaid diagrams, and a Copy-for-AI button.
 
 ### Development Tools
 


### PR DESCRIPTION
Adding Skim, a free open-source Chrome/Firefox extension that live-renders markdown files including Codex CLI's plans and reports. MIT licensed, zero telemetry. https://skim.md

![Skim rendering a markdown file with a table-of-contents sidebar](https://raw.githubusercontent.com/skim-md/skim/main/promo/png/01-hero.png)