### PR TITLE
Add Agent Plugins Directory to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 - [SwarmClaw](https://github.com/swarmclawai/swarmclaw) - Self-hosted multi-agent runtime that delegates to Codex CLI alongside Claude Code, Gemini CLI, OpenCode, Copilot CLI, Cursor Agent, Goose, Qwen Code, and Droid. Org chart view, schedules, runtime skills, persistent memory, and reviewed conversation-to-skill learning. MCP-native (server and client). Electron desktop app, CLI, and Docker.
 - [Alfred](https://github.com/luminik-io/alfred-os) - Self-hosted runtime that turns scoped GitHub issues into reviewed pull requests through autonomous Codex CLI and Claude Code agents. Per-firing Git worktrees, label-driven state machine (agent:implement → agent:in-flight → agent:pr-open → agent:done), role-based engine routing across Codex and Claude, and Slack reporting. Python, MIT, macOS/Linux.
 - [Codex First Task Prompt Generator](https://ronnie2025.github.io/ai-agent-workbench-starter-pack/codex-first-task-prompt-generator.html) - Free web tool that turns a Codex CLI project goal into a scoped first-task prompt with constraints and acceptance checks.
+- [Agent Plugins Directory](https://agentpluginsdirectory.com) - Directory of 524 Agent Plugins, each verified by fetching its `plugin.json` and checking it against the official Agent Plugins 1.0.0 schema, plus a free browser-based validator for `plugin.json` and `mcp.json`. Agent Plugins install in Codex CLI and in ChatGPT, Cursor, Copilot, VS Code and Kiro from the same directory.
 
 ### Stat
 


### PR DESCRIPTION
Project link: https://agentpluginsdirectory.com

Adds one entry to `### Development Tools`.

**What it is.** A directory of every Agent Plugin we can find on GitHub, plus a free browser-based validator for `plugin.json` and `mcp.json`.

**Why it fits this list.** Agent Plugins 1.0.0 shipped on 2026-08-06 from OpenAI, Amazon, Cursor, Microsoft and Vercel, and **Codex CLI is one of the six compatible clients**. A plugin is a directory with `plugin.json` at its root; the same package installs in Codex, ChatGPT, Cursor, Copilot, VS Code and Kiro. The spec ships no registry and no validator — its own FUTURE_CONSIDERATIONS.md says "No test harness or validation tool is specified" — so there was no way to see what exists or check a manifest before publishing it.

**On the numbers.** 524 plugins as of 2026-08-09. Every listing is verified by fetching its `plugin.json` from GitHub and validating it against the official 1.0.0 schema, not by trusting search results. The counting methodology and the deduplication rules are published at https://agentpluginsdirectory.com/stats, and the whole dataset is downloadable as JSON under CC BY 4.0 at https://agentpluginsdirectory.com/census.json, so the count can be audited rather than taken on trust. A daily crawl refreshes it.

The validator runs client-side against the spec's own unmodified schema files, so nothing pasted into it is uploaded or stored.

Happy to move the entry to a different section, shorten the description, or split the validator into its own line if you would prefer.