### PR TITLE
Add GraphCode to Session manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Recently added, actively maintained entries live at the top of each section belo
 - [codexsm](https://github.com/milisp/codexsm) - Codex session manager, cross-platform GUI. Rename, view, or delete session files, with one-click session resume.
 - [agentbox](https://github.com/madarco/agentbox) - Run multiple Codex (and Claude Code / OpenCode) sessions in parallel, each in its own sandboxed box — local Docker or cloud VMs (Hetzner/Daytona/Vercel/E2B). Sub-1s checkpoint starts, per-box browser + VS Code, and a dashboard to switch between boxes.
 - [Orca](https://onorca.dev) - Desktop IDE that runs Codex CLI and other agents (Claude Code, Cursor, Gemini) in parallel, each in its own Git worktree, with built-in terminal and diff review.
+- [GraphCode](https://github.com/scgopi/GraphCode) - macOS app that arranges Codex, Claude Code, and Copilot CLI sessions into a graph. Each node is a live terminal you can attach to mid-run; each edge is a hand-off, message, or spawn that fires while you're away. Sessions survive app quits and reboots.
 
 ### Account switcher
 


### PR DESCRIPTION
Project link: https://github.com/scgopi/GraphCode

Adds GraphCode to **Tools › Session manager**, alongside crystal, codmate and agent-sessions.

It arranges Codex sessions (and Claude Code / Copilot CLI ones) as a graph rather than a list: each node is a live Codex terminal you can attach to and steer mid-run, and each edge is a hand-off, message, or spawn that fires while you're away — so a finished Codex loop can wake another one on its own. Codex activity is read straight out of `~/.codex/sessions/**/rollout-*.jsonl`, so a card shows the tool call the session is currently inside. Sessions survive app quits, daemon restarts, and reboots, resuming with `--resume` rather than starting a duplicate.

- macOS 15+, Apple Silicon; Developer ID signed and notarized
- Entry appended to the end of the section, matching the existing order

Thanks for maintaining the list.