### PR TITLE
Add Skillselion to Tools > MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 - [AccInt](https://github.com/maxbaluev/accreted-intelligence) - Local-first MCP work memory for Codex CLI, Claude Code, OpenCode, and Cursor with scored retrieval, commitment tracking, and outcome-based credit across sessions.
 - [Vestige](https://github.com/samvallad33/vestige) - Local-first cognitive memory MCP server that gives Codex CLI persistent recall across sessions. SQLite storage, FSRS-6 retention with active forgetting so old context decays instead of piling up, prediction-error gating, and hybrid retrieval. Single Rust binary, npm install -g vestige-mcp-server.
 - [GoodMemory](https://github.com/hjqcan/GoodMemory) - Local-first, auditable memory for Codex CLI and Claude Code. `goodmemory setup` installs scoped recall hooks and read-only MCP inspection; SQLite persistence is the default, while optional writeback stays reviewable and reversible.
+- [Skillselion](https://github.com/skillselion/skillselion-mcp) - On-demand skill loader for Codex CLI and Claude Code. Searches a catalog of community agent skills, MCP servers and marketplaces ranked by install count, then materializes the matching SKILL.md plus its bundled scripts into the session mid-task; `synthesize_skills` merges the top matches into one provenance-tagged digest. `npx -y skillselion-mcp`, stdio, read-only, no API key.
 
 ### setup tool
 


### PR DESCRIPTION
Project link: https://github.com/skillselion/skillselion-mcp

**What it does:** an MCP server that gives Codex CLI on-demand access to community agent skills. It searches a catalog of skills, MCP servers and marketplaces ranked by real install counts, then materializes the matching `SKILL.md` plus its bundled scripts and references into the running session, so the agent follows a proven recipe instead of improvising. `synthesize_skills` merges the top ~5 matches into one deduped, provenance-tagged digest.

- Install: `npx -y skillselion-mcp` — stdio, read-only, no auth or API key
- npm: [`skillselion-mcp`](https://www.npmjs.com/package/skillselion-mcp) v0.9.6 · MIT
- Also in the official MCP Registry as `io.github.skillselion/skillselion-mcp` (ACTIVE)

**On your inclusion criteria — being straight with you:** the repo does not have 10+ GitHub stars. What it does have is package traction and active use: **278 npm downloads in the last 30 days, 69 in the last 7**, and the server is published and verified in the official MCP Registry. It is also listed in punkpeye/awesome-mcp-servers (Aggregators) and GetBindu/awesome-claude-code-and-skills. If that is not enough adoption for the list yet, no hard feelings — close it and I will resubmit once the star count catches up.