### PR TITLE
Add SandBase CLI to Codex setup tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 
 - [codex-1up](https://github.com/regenrek/codex-1up) - Equips your Codex CLI coding agent with powerful tools.
 - [codex-universal](https://github.com/openai/codex-universal) - Base Docker image used in Codex environments.
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Auto-configures Codex with a secure MCP bridge to 2,000+ AI tools and 200+ models using one API key, including web search, multimodal generation, and cloud sandbox workflows.
 
 ### Session manager
 


### PR DESCRIPTION
## What changed

Adds SandBase CLI to the `setup tool` section.

## Why it belongs

SandBase CLI directly supports Codex: `sandbase connect --client codex` installs and verifies a persistent MCP configuration, giving Codex access to 2,000+ AI tools and 200+ models through one API key.

## Adoption and activity

- 1,776 npm downloads in the latest completed 30-day npm reporting window (2026-07-11 through 2026-08-09)
- Active public Apache-2.0 repository
- Published npm package: https://www.npmjs.com/package/@sandbaseai/cli

## Validation

- No duplicate SandBase entry
- Added to the most specific setup-tool category
- `git diff --check` passes

Project: https://github.com/sandbaseai/cli