### PR TITLE
Add Aeon to Tools (Development Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 - [Agent Plugins Directory](https://agentpluginsdirectory.com) - Directory of 524 Agent Plugins, each verified by fetching its `plugin.json` and checking it against the official Agent Plugins 1.0.0 schema, plus a free browser-based validator for `plugin.json` and `mcp.json`. Agent Plugins install in Codex CLI and in ChatGPT, Cursor, Copilot, VS Code and Kiro from the same directory.
 - [Claudexor](https://github.com/razzant/claudexor) - Local-first control plane that runs Codex alongside Claude Code, Cursor, and OpenCode, with profile-aware quota routing, best-of-N runs, and cross-family review.
 - [Hexis](https://github.com/Bevel-Software/Hexis) - Git-backed platform for skills, tools, and context for AI agents, available to Codex through a remote OAuth MCP server.
+- [Aeon](https://github.com/aeonfun/aeon) - Autonomous agent framework that runs entirely inside GitHub Actions — cron-scheduled Markdown skills, self-healing (a health skill files issues, a repair skill fixes them by PR), and fleet-replicating. Runs its skills on Codex CLI, one of six supported coding-agent harnesses (Codex, Claude Code, Grok, Pi, Vibe, Kimi), through a single adapter. MIT.
 
 ### Stat
 


### PR DESCRIPTION
Adding **[Aeon](https://github.com/aeonfun/aeon)** under **Tools → Development Tools**.

Aeon is an autonomous agent framework that runs entirely inside GitHub Actions — you enable Markdown "skills", schedule them on cron, and each run is a fresh headless coding-agent invocation. It's self-healing (a health skill files issues and a repair skill fixes them by PR) and fleet-replicating.

Aeon runs its skills on **OpenAI Codex CLI as one of six supported coding-agent harnesses** (Codex, Claude Code, Grok, Pi, Vibe, Kimi) behind a single adapter, so Codex users can drive it headlessly as a scheduled, unattended skill runner. This fits alongside the other agent runtimes/orchestrators in Development Tools (SwarmClaw, Alfred, bernstein, ralph-harness, humanlayer).

- Repo: https://github.com/aeonfun/aeon
- License: MIT · actively maintained (daily commits)
- Meets the inclusion criteria (well over 10 GitHub stars, active use)

Single entry, placed at the end of Development Tools, formatting matches the surrounding lines.