### PR TITLE
docs: update AionUi description to reflect Codex CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 - [CodexMonitor](https://github.com/Dimillian/CodexMonitor) - An app to monitor the Codex situation.
 - [CodexFlow](https://github.com/lulu-sk/CodexFlow) - An enhanced GUI tool designed for Codex CLI, focused on improving conversation management and interaction.
 - [Codex-webui](https://github.com/harryneopotter/Codex-webui) - A minimal web UI to run Codex CLI locally with a UI, session resume, and persistent memory (unofficial).
-- [AionUi](https://github.com/iOfficeAI/AionUi) - Free, local, open-source GUI app for Gemini CLI — Better Chat UI, File Management, AI image editing, multi-agent support, multi-LLMs.
+- [AionUi](https://github.com/iOfficeAI/AionUi) - Open-source desktop client that runs Codex CLI alongside other agent CLIs (Claude Code, Gemini CLI, Qwen Code), with multi-session chat, MCP and ACP support, and local file management.
 - [Untether](https://github.com/littlebearapps/untether) - Telegram bridge for Codex CLI (and 5 other agents). Send tasks by voice, stream progress, toggle approval policy (full auto/safe) via inline buttons.
 - [IM.codes](https://github.com/im4codes/imcodes) - The IM for agents: a mobile/web control layer for Codex CLI and other terminal-based coding agents, with terminal access, file browsing, Git views, localhost preview, notifications, and multi-agent workflows.
 - [Onepilot](https://onepilotapp.com) - Native iOS SSH terminal for Codex CLI and Claude Code. Full PTY, GitHub integration, localhost forwarding, live file editing, and one-click AI agent deployment via OpenClaw. [App Store](https://apps.apple.com/app/onepilot-ai-terminal/id6743826919).


### PR DESCRIPTION
The existing AionUi entry describes it as a "GUI app for Gemini CLI", which is out of date — AionUi now runs Codex CLI as a first-class agent alongside Claude Code, Gemini CLI and Qwen Code.

This updates the one-line description to match the project's current scope and the style of neighbouring entries. No new entry is added, no other lines changed.