### PR TITLE
Add codex-healthkit to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 - [Claudexor](https://github.com/razzant/claudexor) - Local-first control plane that runs Codex alongside Claude Code, Cursor, and OpenCode, with profile-aware quota routing, best-of-N runs, and cross-family review.
 - [Hexis](https://github.com/Bevel-Software/Hexis) - Git-backed platform for skills, tools, and context for AI agents, available to Codex through a remote OAuth MCP server.
 - [Aeon](https://github.com/aeonfun/aeon) - Autonomous agent framework that runs entirely inside GitHub Actions — cron-scheduled Markdown skills, self-healing (a health skill files issues, a repair skill fixes them by PR), and fleet-replicating. Runs its skills on Codex CLI, one of six supported coding-agent harnesses (Codex, Claude Code, Grok, Pi, Vibe, Kimi), through a single adapter. MIT.
+- [codex-healthkit](https://github.com/Ishikawa-Hidekazu/codex-healthkit) - On-demand, metadata-only health reports for Codex CLI session storage and SQLite WAL growth, with explicit before/after comparisons and no credential, database-content, or transcript reads.
 
 ### Stat
 


### PR DESCRIPTION
## 🛠️ Changes Proposed

- [x] Add [codex-healthkit](https://github.com/Ishikawa-Hidekazu/codex-healthkit) to **Tools → Development Tools**.
- [x] Keep the change to one concise, non-duplicated README entry.

codex-healthkit provides on-demand, metadata-only health reports for Codex CLI session storage and SQLite WAL growth. It supports explicit before/after comparisons without reading credentials, database contents, or session transcripts.

## Inclusion evidence

This is a low-traction project (currently 1 GitHub star), so the submission relies on the active-use path in the inclusion criteria rather than the 10-star threshold:

- used daily in a real Codex Pro environment
- stable source-only release [`v0.4.0`](https://github.com/Ishikawa-Hidekazu/codex-healthkit/releases/tag/v0.4.0), published on 2026-08-10
- [24-second reproducible terminal demo](https://raw.githubusercontent.com/Ishikawa-Hidekazu/codex-healthkit/main/assets/terminal-demo.gif)
- maintained public test suite with successful macOS and Linux CI
- a narrow Codex-specific use case: diagnosing local session-storage and SQLite WAL growth without collecting transcript or secret data

## ✅ Checklist

- [ ] Relevant to Codex CLI, no self-promotion, no duplicate.
  - It is directly relevant to Codex CLI and no duplicate was found. I maintain the submitted project, so I am intentionally leaving the combined self-promotion checkbox unchecked for maintainer review.
- [x] Meets the [inclusion criteria](https://github.com/milisp/awesome-codex-cli/blob/main/CONTRIBUTING.md#inclusion-criteria) through clear evidence of active use, recent maintenance, and a working demo.

## Disclosure

I maintain codex-healthkit. This is not an anonymous third-party recommendation. The README change and this submission were prepared with Codex under my direction.

## Validation

- `git diff --check`
- repository URL: HTTP 200
- v0.4.0 release URL: HTTP 200
- terminal demo URL: HTTP 200
- duplicate repository URL count in README: 1

## 🤖 Anti-Bot / Human Verification

**Which AI tools or shell workflows do you currently use day-to-day?**

- [ ] Codexia
- [x] Codex
