### PR TITLE
docs: trim the PR template's verification section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,9 +35,7 @@
 - [ ] No duplicate; one entry in one section.
 - [ ] One factual line, no marketing copy.
 
-## 🤖 Anti-Bot / Human Verification
-> To ensure quality contributions and filter out automated spam agents, please answer the quick question below:
+## 🤖 Human Check
+> A one-line answer, to filter out automated spam submissions.
 
-**Which AI tools or shell workflows do you currently use day-to-day?**
-- [ ] Codexia
-- [ ] Codex
+**What do you actually use Codex CLI for day-to-day?**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,8 +34,3 @@
 - [ ] Real Codex CLI integration, not just a "supports Codex" mention.
 - [ ] No duplicate; one entry in one section.
 - [ ] One factual line, no marketing copy.
-
-## 🤖 Human Check
-> A one-line answer, to filter out automated spam submissions.
-
-**What do you actually use Codex CLI for day-to-day?**


### PR DESCRIPTION
Follow-up to #104, touching only `.github/PULL_REQUEST_TEMPLATE.md`.

**Removed Codexia from the verification field.** That field is mandatory for everyone opening a PR, so listing the maintainer's own product there put it in front of contributors at the moment they're asking for a merge — different in kind from Featured, which is a curation statement a reader can skip.

**Then removed the question entirely.** The adoption-evidence fields already do this job, and do it better: they ask for specific numbers that get checked against GitHub and npm, so a spam PR either leaves them blank or fabricates them. Two checkboxes filtered no bots and cost real contributors a field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)