### PR TITLE
Add Codex Theme Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 - [MCP Linker](https://github.com/milisp/mcp-linker) - GUI for managing MCP configs for Codex CLI.
 - [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data extraction skill & MCP server for AI coding agents. 20 tools: followers, tweets, replies, mentions, lists, hashtags, spaces & more.
 - [Codex Skins](https://codexskins.org) - One-click wallpaper/theme gallery for the OpenAI Codex desktop app. Reversible full-window CDP theme injection, macOS/Windows. Open-source engine (MIT).
+- [Codex Theme Builder](https://codextheme.tools) - Free browser theme builder for OpenAI Codex with live preview and CSS token export.
 
 ### MCP server
 


### PR DESCRIPTION
Adds [Codex Theme Builder](https://codextheme.tools) under **GUI & MCP**, next to Codex Skins.

It is a free browser theme builder for the OpenAI Codex desktop/web workflow: live preview and CSS token export. Public site, no signup required.