### PR TITLE
Document GoodMemory install prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 - [AccInt](https://github.com/maxbaluev/accreted-intelligence) - Local-first MCP work memory for Codex CLI, Claude Code, OpenCode, and Cursor with scored retrieval, commitment tracking, and outcome-based credit across sessions.
 - [Agent QA](https://github.com/vostride/agent-qa) - The self-improving QA agent for software teams. Run `agent-qa mcp` to let Codex author and execute natural-language web/mobile tests, inspect artifacts, triage failures, and guide fixes with persistent test memory.
 - [Vestige](https://github.com/samvallad33/vestige) - Local-first cognitive memory MCP server that gives Codex CLI persistent recall across sessions. SQLite storage, FSRS-6 retention with active forgetting so old context decays instead of piling up, prediction-error gating, and hybrid retrieval. Single Rust binary, npm install -g vestige-mcp-server.
-- [GoodMemory](https://github.com/hjqcan/GoodMemory) - Local-first, auditable memory for Codex CLI and Claude Code. `goodmemory setup` installs scoped recall hooks and read-only MCP inspection; SQLite persistence is the default, while optional writeback stays reviewable and reversible.
+- [GoodMemory](https://github.com/hjqcan/GoodMemory) - Local-first, auditable memory for Codex CLI and Claude Code. Install with `npm install -g goodmemory` (Node.js 20+ and Bun 1.3.14+), then run `goodmemory setup` for scoped recall hooks and read-only MCP inspection; SQLite persistence is the default, while optional writeback stays reviewable and reversible.
 
 ### setup tool
 


### PR DESCRIPTION
## 🛠️ Changes Proposed

- [x] Add the missing copy-ready `npm install -g goodmemory` step to the existing GoodMemory entry.
- [x] State the published package runtime requirements: Node.js 20+ and Bun 1.3.14+.
- [x] Keep the existing neutral capability description and avoid a version pin that would immediately become stale.

### 📈 Proof of Traction

This is maintenance of an already accepted entry, not a new traction claim. Current authoritative package evidence:

- npm `latest`: `goodmemory@0.7.5`
- published `engines`: Node `>=20.0.0`, Bun `>=1.3.14`
- official MCP Registry: `io.github.hjqcan/goodmemory` 0.7.5

Downloads, stars, scans, and maintainer-run tests are intentionally not presented as independent adoption.

### ✅ Quick Check

- [x] Real Codex CLI integration
- [x] No duplicates & neutral description

Validation: `npm view goodmemory@0.7.5 version engines --json`; `git diff --check`.