### PR TITLE
Add Chinese ChatGPT Plus / Pro and Codex guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ legacy code and architecture.
 ### Learning Resources
 
 - [Apidog Blog](https://apidog.com/blog/openai-codex-cli/) - Open source coding agent overview.
+- [ChatGPT Plus / Pro and Codex Guide (Chinese)](https://github.com/momochoog/gpt-daichong) - MIT-licensed Chinese guide to choosing ChatGPT Plus or Pro for Codex, separating ChatGPT subscriptions from API billing, and checking payment, order, and credential-safety steps; maintained by AIXiamo.
 
 Community tutorials and examples are welcome.
 


### PR DESCRIPTION
Project: https://github.com/momochoog/gpt-daichong

## 🛠️ Changes Proposed
- [x] Add a Chinese community guide to Learning Resources. It helps Codex users distinguish ChatGPT subscription access from API billing, choose between Plus and Pro by usage pattern, and check payment, order, and credential-safety steps.

### 📈 Proof of Traction
The repository currently has 120 stars and 2 forks. It is also referenced by the merged Codex-Manager contribution [qxcnm/codex-manager#439](https://github.com/qxcnm/codex-manager/pull/439).

### ✅ Quick Check
- [ ] Real Codex CLI integration — this is a learning resource rather than an installable integration; its Codex relevance is subscription access, plan choice, and API-billing boundaries.
- [x] No duplicates and neutral description (no marketing copy).

Disclosure: I maintain the guide and operate AIXiamo, whose first-party service links appear in it. The guide is independent of OpenAI and is not presented as an independent review. This PR adds only the GitHub repository link and factual wording; it does not add a product or checkout link.