### PR TITLE
Add SandBase CLI MCP bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 - [Agent QA](https://github.com/vostride/agent-qa) - The self-improving QA agent for software teams. Run `agent-qa mcp` to let Codex author and execute natural-language web/mobile tests, inspect artifacts, triage failures, and guide fixes with persistent test memory.
 - [Vestige](https://github.com/samvallad33/vestige) - Local-first cognitive memory MCP server that gives Codex CLI persistent recall across sessions. SQLite storage, FSRS-6 retention with active forgetting so old context decays instead of piling up, prediction-error gating, and hybrid retrieval. Single Rust binary, npm install -g vestige-mcp-server.
 - [GoodMemory](https://github.com/hjqcan/GoodMemory) - Local-first, auditable memory for Codex CLI and Claude Code. `goodmemory setup` installs scoped recall hooks and read-only MCP inspection; SQLite persistence is the default, while optional writeback stays reviewable and reversible.
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Open-source MCP bridge that configures Codex CLI with six tools for discovering, inspecting, and running 2,000+ AI models and APIs; install with `npx -y @sandbaseai/cli connect --client codex`.
 
 ### setup tool
 


### PR DESCRIPTION
## Summary

Adds one factual SandBase CLI entry to the **MCP server** section.

## Fit and verification

- Real Codex CLI integration: `connect --client codex` writes an ownership-marked `[mcp_servers.sandbase]` entry to Codex configuration.
- Public Apache-2.0 source: https://github.com/sandbaseai/cli
- Published npm package: https://www.npmjs.com/package/@sandbaseai/cli
- Official MCP Registry entry: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.sandbaseai%2Fcli/versions/0.1.17
- Current repository signals: 59 stars and 5 forks at submission time.
- The project has external directory submissions and an open Docker MCP Registry review.

## Checks

- `git diff --check`
- Verified the Codex client profile and TOML adapter in public source
- Confirmed the documented six-tool surface and 2,000+ catalog positioning

Disclosure: I am affiliated with SandBase. This submission was prepared with AI assistance and checked against the public source and registries.