### PR TITLE
Update Hephaestus entry to Agentlas OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 - [Plux](https://milisp.dev/plux) - Capture now with a shortcut. Turn it into a todo, send it to AI anytime.
 - [humanlayer](https://github.com/humanlayer/humanlayer) - The best way to get AI coding agents to solve hard problems in complex codebases.
 - [ralph-harness](https://github.com/rxdt/py_ralph_frame) - Minimal repo-local loop scaffold for Codex CLI, Claude Code, and Gemini CLI. Uses `PROMPT.md`, specs, fresh-context iterations, Git hooks, CI verification, and hard iteration/time caps so agents make small gated commits instead of drifting in one long chat.
-- [Hephaestus](https://github.com/agentlas-ai/Hephaestus) - Open Agent OS for Claude Code, Codex, and Cursor: meta-agent builder, A2A Hub routing, local ontology, and memory/security gates.
+- [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Local-first Agent OS that packages specialist agents and temporary teams, with a Codex adapter, MCP/A2A routing, and verification gates.
 - [Agent FM](https://github.com/agentfm-ai/agent-fm) - Local macOS app for listening to Claude Code and Codex agents, with Global Mix, blocker alerts, and BYOK narration.
 - [Relay Baton](https://github.com/guorunjie/codex-relay-baton-guardian) - Local Codex Desktop/CLI recovery monitor for long-running tasks. Detects compact failures and context-window overflow, then queues audited handoff bundles.
 - [EchoCoding](https://github.com/launsion-boop/EchoCoding) - Audio layer for Codex CLI with hook-triggered SFX, ambient soundscape, and optional cloud TTS/ASR voice interaction.


### PR DESCRIPTION
## Summary

Updates the existing Hephaestus listing to the current Agentlas OS name, canonical repository, and a factual one-line description of its Codex integration.

## Verification

- Existing entry only; no new listing
- One README line
- git diff --check: passed

Disclosure: I am submitting this update on behalf of the Agentlas project.