### PR TITLE
Add Codex Account Switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 ### Account switcher
 
 - [codex-account](https://github.com/frndchagas/codex-account) - Switch between multiple Codex accounts without signing out — never revokes tokens, keeps every account signed in, and syncs refreshed tokens back into saved profiles. Single-file bash script.
+- [Codex Account Switcher](https://github.com/liuzhao1225/codex-account-switcher) - Native macOS menu bar app that switches the active Codex Desktop and newly started Codex CLI account locally, with no Terminal commands or config-file editing.
 
 ### WebUI & App
 


### PR DESCRIPTION
## 🛠️ Changes Proposed

- [x] Add Codex Account Switcher to **Tools → Account switcher** with one factual line.

Project: https://github.com/liuzhao1225/codex-account-switcher

### 📈 Proof of Traction

- The Apple-notarized v0.1.5 DMG has 52+ downloads as of August 31, 2026: https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.5
- The Awesome Mac maintainer independently featured the app on X, where the post reached about 2,000 views: https://x.com/jaywcjlove/status/2093970264120078614

### ✅ Quick Check

- [x] Real Codex CLI integration: the app switches the active local Codex credential used by newly started CLI processes, while existing sessions keep running.
- [x] No duplicates and a neutral, one-line description.

Disclosure: I create and maintain this app.