### PR TITLE
Add ACP for Codex (Development Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 - [Ouroboros (razzant)](https://github.com/razzant/ouroboros) - Self-hosted AI agent runtime with a headless CLI, persistent memory, reviewed self-modification, and Codex CLI integration.
 - [Hexis](https://github.com/Bevel-Software/Hexis) - Git-backed platform for skills, tools, and context for AI agents, available to Codex through a remote OAuth MCP server.
 - [Aeon](https://github.com/aeonfun/aeon) - Autonomous agent framework that runs entirely inside GitHub Actions — cron-scheduled Markdown skills, self-healing (a health skill files issues, a repair skill fixes them by PR), and fleet-replicating. Runs its skills on Codex CLI, one of six supported coding-agent harnesses (Codex, Claude Code, Grok, Pi, Vibe, Kimi), through a single adapter. MIT.
+- [ACP for Codex](https://github.com/agentic-control-plane/codex-acp-plugin) - Agentic Control Plane hook for Codex CLI. Each shell command is checked against policy before it runs and priced at API rates, with an audit trail.
 
 ### Stat
 


### PR DESCRIPTION
Adds the Agentic Control Plane hook for Codex CLI under Development Tools.

Checks each Codex shell command against policy before it runs (allow/ask/deny), prices calls at API rates, and keeps an audit trail. MIT.

Related reference we maintain on what Codex hooks can and cannot do today: https://agenticcontrolplane.com/blog/codex-cli-hooks-reference

Disclosure: I maintain Agentic Control Plane.