### PR TITLE
Add great_cto to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 - [Ouroboros (razzant)](https://github.com/razzant/ouroboros) - Self-hosted AI agent runtime with a headless CLI, persistent memory, reviewed self-modification, and Codex CLI integration.
 - [Hexis](https://github.com/Bevel-Software/Hexis) - Git-backed platform for skills, tools, and context for AI agents, available to Codex through a remote OAuth MCP server.
 - [Aeon](https://github.com/aeonfun/aeon) - Autonomous agent framework that runs entirely inside GitHub Actions — cron-scheduled Markdown skills, self-healing (a health skill files issues, a repair skill fixes them by PR), and fleet-replicating. Runs its skills on Codex CLI, one of six supported coding-agent harnesses (Codex, Claude Code, Grok, Pi, Vibe, Kimi), through a single adapter. MIT.
+- [great_cto](https://github.com/avelikiy/great_cto) - Ships nine skills and an MCP server to Codex CLI, and runs Codex as a second-opinion reviewer on the same diff from inside Claude Code.
 
 ### Stat
 


### PR DESCRIPTION
One entry, one section, one factual line — per `contributing.md`.

```
- [great_cto](https://github.com/avelikiy/great_cto) - Ships nine skills and an MCP server to Codex CLI, and runs Codex as a second-opinion reviewer on the same diff from inside Claude Code.
```

**Against your two criteria:**

- *Proven external usage* — 89 stars, **8,650 npm downloads last month** (`great-cto`).
- *Real integration, not a mention* — [`.codex-plugin/plugin.json`](https://github.com/avelikiy/great_cto/blob/main/.codex-plugin/plugin.json) declares nine skills and the MCP server config; the server itself is [`packages/cli/src/mcp.ts`](https://github.com/avelikiy/great_cto/blob/main/packages/cli/src/mcp.ts) (stdio JSON-RPC, seven tools, no runtime dependencies).

**What it does not claim:** the full agent pipeline does *not* run on Codex — that is Claude Code. On Codex you get the skills bundle and the MCP server, and Codex additionally serves as the cross-model reviewer. The line above says exactly that and nothing more.

MIT. Opened by an automated agent on the maintainer's behalf.