### PR TITLE
Add YYLO to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 - [Hexis](https://github.com/Bevel-Software/Hexis) - Git-backed platform for skills, tools, and context for AI agents, available to Codex through a remote OAuth MCP server.
 - [Aeon](https://github.com/aeonfun/aeon) - Autonomous agent framework that runs entirely inside GitHub Actions — cron-scheduled Markdown skills, self-healing (a health skill files issues, a repair skill fixes them by PR), and fleet-replicating. Runs its skills on Codex CLI, one of six supported coding-agent harnesses (Codex, Claude Code, Grok, Pi, Vibe, Kimi), through a single adapter. MIT.
 - [great_cto](https://github.com/avelikiy/great_cto) - Ships nine skills and an MCP server to Codex CLI, and runs Codex as a second-opinion reviewer on the same diff from inside Claude Code.
+- [YYLO](https://github.com/yylo-dev/yylo) - Command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries. Runs Pi and Codex subagents, gives each task a dedicated branch/worktree, and gates merges with a risk-based review queue and receipt-backed changes. MIT, npm @yylo/cli.
 
 ### Stat
 


### PR DESCRIPTION
## 🛠️ Changes Proposed

Adds **YYLO** to `### Development Tools` (one entry, one section, one factual line, appended at the section tail per the freshest merged adds #118/#112).

- Project link: https://github.com/yylo-dev/yylo
- What it is: a command-line orchestrator for coding agents (terminal, `yylo`/`yy`), MIT-licensed, installable from npm as `@yylo/cli`.

YYLO runs Pi and Codex as subagent engines inside a dedicated branch/worktree per task, wraps each task in typed task/validation/merge/release-readiness boundaries, and routes integration through a risk-based merge queue (low risk: no semantic reviewer; high risk: two sequential reviewers on one frozen candidate) with receipt-backed, hash-verified changes. It sits beside the in-section orchestrators (claude-squad, bernstein, SwarmClaw, Alfred) as the merge-governance layer: the task → isolated worktree → validation → gated-merge loop is the unit.

### 📈 Proof of Traction

- 57 GitHub stars, created 2026-01-06, daily pushes (8 months of continuous development): https://github.com/yylo-dev/yylo
- npm `@yylo/cli`: 780 downloads in the last month — https://api.npmjs.org/downloads/point/last-month/@yylo/cli
- Listed in 20 other curated awesome lists via merged PRs (e.g. Engineering4AI/awesome-spec-driven-development #25, systempromptio/awesome-ai-agent-governance #72, Piebald-AI/awesome-gemini-cli #116, kailiu42/awesome-coding-agents #44).

### ✅ Quick Check

- [x] Real Codex CLI integration — Codex is a first-class subagent namespace (`--subagent codex`), with its own model-alias table distinct from Pi's (README: "Pi and Codex do not share the same `:mini` mapping"). YYLO drives Codex sessions as the working agents in the task loop, not just a README mention.
- [x] No duplicates & neutral description — grepped the README for `yylo` (0 hits); every phrase in the entry line is copied from the project's own README (no marketing copy).

### Disclosure

I'm on the team that builds YYLO; this PR (branch, entry, body) was prepared with an AI coding agent and reviewed by me before submission. Happy to adjust the section placement or description if the fit is better elsewhere.
