### PR TITLE
Add codex-switch: provider switching with cross-provider session resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ OpenAI Codex CLI is a lightweight coding agent that runs in your terminal.
 ### Account switcher
 
 - [codex-account](https://github.com/frndchagas/codex-account) - Switch between multiple Codex accounts without signing out — never revokes tokens, keeps every account signed in, and syncs refreshed tokens back into saved profiles. Single-file bash script.
+- [codex-switch](https://github.com/aipmer/codex-switch) - One-click switching between OpenAI official, DeepSeek, and Kimi Code providers on macOS, with automated cross-provider session resume (model-name rewriting + reasoning cleanup). Bilingual docs (中文/EN).
 
 ### WebUI & App
 


### PR DESCRIPTION
Adding [codex-switch](https://github.com/aipmer/codex-switch) to the Account switcher section.

One-click switching between OpenAI official (ChatGPT subscription), DeepSeek, and Kimi Code for Codex on macOS. Distinguishing feature: **automated cross-provider session resume** — handles two empirically-verified blockers (session-metadata model-name pinning in pre-sampling compaction, and third-party reasoning items rejected by the official API). Verified on Codex 0.153.4. Bilingual README (中文/English), MIT.